### PR TITLE
safer looping in main

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,18 +36,21 @@ async fn main() -> Exit<()> {
             loop {
                 tokio::select! {
                     notification = stream.next() => {
-                        if let Some(Notification::Alive {
+                        match notification {
+                            Some(Notification::Alive {
                                 ref notification_type,
                                 ref unique_service_name,
                                 ref location,
-                            }) = notification
-                            && !known_services.contains_key(unique_service_name)
-                            {
+                            }) if !known_services.contains_key(unique_service_name) => {
                                 println!("+ {notification_type}");
                                 println!("  {unique_service_name} at {location}");
                                 known_services.insert(unique_service_name.clone(), notification.expect("inside if let Some"));
                             }
-                        },
+                            Some(Notification::Alive{..}) => todo!(),
+                            Some(Notification::ByeBye{..}) => todo!(),
+                            None => todo!(),
+                        }
+                    },
                     e = netif.next() => {
                         if let Some(Ok(event)) = e {
                             ssdp.on_network_event(&event)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,17 +69,32 @@ async fn main() -> Exit<()> {
                             }) => {
                                 match known_services.insert(unique_service_name.clone(), KnownService::from_notification(notification).expect("This is an alive")) {
                                     None => {
-                                        println!("+ {notification_type}");
-                                        println!("  {unique_service_name} at {location}");
+                                        println!("+  {notification_type}");
+                                        println!("   {unique_service_name} at {location}");
                                     }
                                     Some(previous) if previous != KnownService::from_notification(notification).expect("This is an alive") => {
-                                        println!("! {} -> {}", previous.service_type, notification_type);
-                                        println!("  {unique_service_name} at {} -> {}", previous.location, location);
+                                        println!("!  {} -> {}", previous.service_type, notification_type);
+                                        println!("   {unique_service_name} at {} -> {}", previous.location, location);
                                     },
                                     Some(_) => (),
                                 }
                             }
-                            Some(Notification::ByeBye{..}) => todo!(),
+                            Some(Notification::ByeBye{ notification_type, unique_service_name }) => {
+                                match known_services.remove_entry(&unique_service_name) {
+                                    None =>{
+                                        println!("+- {notification_type}");
+                                        println!("   {unique_service_name} at unknown");
+                                    },
+                                    Some((_, previous)) => {
+                                        if previous.service_type == notification_type {
+                                            println!("!- {} -> {}", previous.service_type, notification_type);
+                                        } else {
+                                            println!(" - {}", previous.service_type);
+                                        }
+                                        println!("   {unique_service_name} at {}", previous.location);
+                                    },
+                                }
+                            }
                             None => todo!(),
                         }
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,31 @@ use uuid::Uuid;
 mod cli;
 use cli::*;
 
+#[derive(Debug, Clone, PartialEq, PartialOrd)]
+struct KnownService {
+    service_type: String,
+    location: String,
+}
+type UniqueServiceName = String;
+
+type KnownServices = HashMap<UniqueServiceName, KnownService>;
+
+impl KnownService {
+    fn from_notification(notification: &Notification) -> Option<Self> {
+        match notification {
+            Notification::Alive {
+                notification_type: service_type,
+                unique_service_name: _,
+                location,
+            } => Some(Self {
+                service_type: service_type.clone(),
+                location: location.clone(),
+            }),
+            Notification::ByeBye { .. } => None,
+        }
+    }
+}
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Exit<()> {
     let splurt = Splurt::try_parse()?;
@@ -30,23 +55,30 @@ async fn main() -> Exit<()> {
         //      See #5 & #6
         Command::Ssdp => {
             let mut netif = cotton_netif::get_interfaces_async()?;
-            let mut known_services = HashMap::<String, Notification>::new();
+            let mut known_services = KnownServices::new();
             let mut ssdp = AsyncService::new()?;
             let mut stream = ssdp.subscribe("ssdp:all");
             loop {
                 tokio::select! {
                     notification = stream.next() => {
                         match notification {
-                            Some(Notification::Alive {
+                            Some(ref notification @ Notification::Alive {
                                 ref notification_type,
                                 ref unique_service_name,
                                 ref location,
-                            }) if !known_services.contains_key(unique_service_name) => {
-                                println!("+ {notification_type}");
-                                println!("  {unique_service_name} at {location}");
-                                known_services.insert(unique_service_name.clone(), notification.expect("inside if let Some"));
+                            }) => {
+                                match known_services.insert(unique_service_name.clone(), KnownService::from_notification(notification).expect("This is an alive")) {
+                                    None => {
+                                        println!("+ {notification_type}");
+                                        println!("  {unique_service_name} at {location}");
+                                    }
+                                    Some(previous) if previous != KnownService::from_notification(notification).expect("This is an alive") => {
+                                        println!("! {} -> {}", previous.service_type, notification_type);
+                                        println!("  {unique_service_name} at {} -> {}", previous.location, location);
+                                    },
+                                    Some(_) => (),
+                                }
                             }
-                            Some(Notification::Alive{..}) => todo!(),
                             Some(Notification::ByeBye{..}) => todo!(),
                             None => todo!(),
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,7 +95,10 @@ async fn main() -> Exit<()> {
                                     },
                                 }
                             }
-                            None => todo!(),
+                            None => {
+                                println!("SSDP listener closed");
+                                break
+                            },
                         }
                     },
                     e = netif.next() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,9 +101,13 @@ async fn main() -> Exit<()> {
                             }
                         }
                     },
-                    e = netif.next() => {
-                        if let Some(Ok(event)) = e {
-                            ssdp.on_network_event(&event)?;
+                    event = netif.next() => {
+                        match event {
+                            Some(event) => ssdp.on_network_event(&event?)?,
+                            None => {
+                                println!("Network inteface monitor closed");
+                                break
+                            }
                         }
                     }
                 }
@@ -120,10 +124,13 @@ async fn main() -> Exit<()> {
             println!("advertising with uuid {}", uuid);
             ssdp.advertise(uuid.to_string(), test_service);
             loop {
-                let event = netif.next().await;
-                if let Some(event) = event {
-                    ssdp.on_network_event(&event?)?;
-                }
+                match netif.next().await {
+                    Some(event) => ssdp.on_network_event(&event?)?,
+                    None => {
+                        println!("Network inteface monitor closed");
+                        break;
+                    }
+                };
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,12 +65,13 @@ async fn main() -> Exit<()> {
                                 ref unique_service_name,
                                 ref location,
                             }) => {
-                                match known_services.insert(unique_service_name.clone(), KnownService::from_notification(notification).expect("This is an alive")) {
+                                let service = KnownService::from_notification(notification).expect("This is an alive");
+                                match known_services.insert(unique_service_name.clone(), service.clone()) {
                                     None => {
                                         println!("+  {notification_type}");
                                         println!("   {unique_service_name} at {location}");
                                     }
-                                    Some(previous) if previous != KnownService::from_notification(notification).expect("This is an alive") => {
+                                    Some(previous) if previous != service => {
                                         println!("!  {} -> {}", previous.service_type, notification_type);
                                         println!("   {unique_service_name} at {} -> {}", previous.location, location);
                                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ async fn main() -> Exit<()> {
                         match event {
                             Some(event) => ssdp.on_network_event(&event?)?,
                             None => {
-                                println!("Network inteface monitor closed");
+                                println!("Network interface monitor closed");
                                 break
                             }
                         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,9 +86,9 @@ async fn main() -> Exit<()> {
                                     },
                                     Some((_, previous)) => {
                                         if previous.service_type == notification_type {
-                                            println!("!- {} -> {}", previous.service_type, notification_type);
-                                        } else {
                                             println!(" - {}", previous.service_type);
+                                        } else {
+                                            println!("!- {} -> {}", previous.service_type, notification_type);
                                         }
                                         println!("   {unique_service_name} at {}", previous.location);
                                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -98,7 +98,7 @@ async fn main() -> Exit<()> {
                             None => {
                                 println!("SSDP listener closed");
                                 break
-                            },
+                            }
                         }
                     },
                     e = netif.next() => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,8 +51,6 @@ async fn main() -> Exit<()> {
                 println!("{:?}", e);
             }
         }
-        //TODO: This is directly from the cotton example and needs a bit of rework.
-        //      See #5 & #6
         Command::Ssdp => {
             let mut netif = cotton_netif::get_interfaces_async()?;
             let mut known_services = KnownServices::new();


### PR DESCRIPTION
Moves a little away from the cotton-ssdp example to make the main async loops a bit safer.

Fixes #5
Closes #6