### PR TITLE
Ssdp searcher

### DIFF
--- a/ssdp-rs/Cargo.toml
+++ b/ssdp-rs/Cargo.toml
@@ -17,7 +17,6 @@ async-datagram = "3.0.0"
 async-ready = "3.0.0"
 futures = "0.3.32"
 futures-net = "0.6.0"
-semver = "1.0.28"
 socket2 = { version = "0.6.3", features = ["all"] }
 uuid = "1.23.1"
 

--- a/ssdp-rs/Cargo.toml
+++ b/ssdp-rs/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.32"
 futures-net = "0.6.0"
 osinfo = "1.0.0"
 socket2 = { version = "0.6.3", features = ["all"] }
-uuid = "1.23.1"
+uuid = { version = "1.23.1", features = ["v4"] }
 
 [build-dependencies]
 autocfg = { workspace = true }

--- a/ssdp-rs/Cargo.toml
+++ b/ssdp-rs/Cargo.toml
@@ -17,6 +17,7 @@ async-datagram = "3.0.0"
 async-ready = "3.0.0"
 futures = "0.3.32"
 futures-net = "0.6.0"
+osinfo = "1.0.0"
 socket2 = { version = "0.6.3", features = ["all"] }
 uuid = "1.23.1"
 

--- a/ssdp-rs/Cargo.toml
+++ b/ssdp-rs/Cargo.toml
@@ -17,7 +17,9 @@ async-datagram = "3.0.0"
 async-ready = "3.0.0"
 futures = "0.3.32"
 futures-net = "0.6.0"
+semver = "1.0.28"
 socket2 = { version = "0.6.3", features = ["all"] }
+uuid = "1.23.1"
 
 [build-dependencies]
 autocfg = { workspace = true }

--- a/ssdp-rs/src/lib.rs
+++ b/ssdp-rs/src/lib.rs
@@ -3,4 +3,5 @@
 #![cfg_attr(unstable_let_chains, feature(let_chains))]
 
 pub mod message;
+pub mod search;
 pub mod udp;

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -1,3 +1,10 @@
+//! UPnP Messages as per UPnP Device Architecture 2.0 (revision 2020-04-17)
+//! 
+//! Message generation is strict to standard.
+//! 
+//! Message parsing is lenient - I've have yet to see a single well-formed spec-conform UPnP
+//! message flying around on my network.
+
 use std::{collections::HashMap, fmt::Display};
 
 use semver::Version;
@@ -14,7 +21,7 @@ pub enum Message {
     Search(MSearch),
 }
 
-/// Formats Message as per OCF specification (2015)
+/// Formats Message as per OCF specification (2020)
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -35,7 +42,7 @@ pub struct MSearch {
 }
 
 /// Entire valid M-SEARCH message including initial method line,
-/// as per OCF specification (2015) section 1.3.2
+/// as per OCF specification (2020) section 1.3.2
 ///
 /// #### Note:
 /// I've rarely actually seen a well-formed spec-conform M-SEARCH flying around my network
@@ -72,7 +79,7 @@ struct UserAgent {
     product_version: Version,
 }
 
-/// Formatted as per OCF specification (2015) section 1.3.2 for the `USER-AGENT` *value*,
+/// Formatted as per OCF specification (2020) section 1.3.2 for the `USER-AGENT` *value*,
 /// does NOT include the header key
 impl Display for UserAgent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -26,7 +26,7 @@ pub enum Message {
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Message::Alive(_notification) => todo!(),
+            Message::Alive(_notification) => todo!("display alive messages"),
             Message::Search(msearch) => {
                 write!(f, "{msearch}")
             }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -14,7 +14,7 @@ pub enum Message {
     Search(MSearch),
 }
 
-/// Formats Message as per SSDP specifications
+/// Formats Message as per OCF spec (2015)
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -59,7 +59,7 @@ struct UserAgent {
     product_version: Version,
 }
 
-/// As required by SSDP spec for the *value*, does NOT include a header key
+/// As required by OCF spec (2015) for the *value*, does NOT include a header key
 impl Display for UserAgent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -1,7 +1,7 @@
 //! UPnP Messages as per UPnP Device Architecture 2.0 (revision 2020-04-17)
-//! 
+//!
 //! Message generation is strict to standard.
-//! 
+//!
 //! Message parsing is lenient - I've have yet to see a single well-formed spec-conform UPnP
 //! message flying around on my network.
 

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -1,9 +1,11 @@
-//! UPnP Messages as per UPnP Device Architecture 2.0 (revision 2020-04-17)
+//! UPnP Messages as per [UPnP Device Architecture 2.0 (revision 2020-04-17)][spec]
 //!
 //! Message generation is strict to standard.
 //!
 //! Message parsing is lenient - I've have yet to see a single well-formed spec-conform UPnP
 //! message flying around on my network.
+//!
+//! [spec]: https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf
 
 use std::{collections::HashMap, fmt::Display};
 

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -14,30 +14,13 @@ pub enum Message {
     Search(MSearch),
 }
 
-/// Formats Message as per OCF spec (2015)
+/// Formats Message as per OCF specification (2015)
 impl Display for Message {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Message::Alive(_notification) => todo!(),
-            Message::Search(MSearch {
-                mx,
-                user_agent,
-                friendly_name,
-                uuid,
-            }) => {
-                writeln!(f, "M-SEARCH * HTTP/1.1")?;
-                writeln!(f, "HOST: 239.255.255.250:1900")?;
-                writeln!(f, r#"MAN: "ssdp:discover""#)?;
-                writeln!(f, "MX: {}", mx)?;
-                writeln!(f, "ST: ssdp:all")?;
-                if let Some(user_agent) = user_agent {
-                    writeln!(f, "USER-AGENT: {}", user_agent)?;
-                }
-                writeln!(f, "CPFN.UPNP.ORG: {}", friendly_name)?;
-                if let Some(uuid) = uuid {
-                    writeln!(f, "CPUUID.UPNP.ORG: {}", uuid)?;
-                }
-                writeln!(f)
+            Message::Search(msearch) => {
+                write!(f, "{msearch}")
             }
         }
     }
@@ -51,6 +34,36 @@ pub struct MSearch {
     uuid: Option<Uuid>,
 }
 
+/// Entire valid M-SEARCH message including initial method line,
+/// as per OCF specification (2015) section 1.3.2
+///
+/// #### Note:
+/// I've rarely actually seen a well-formed spec-conform M-SEARCH flying around my network
+/// but there's nothing wrong with actually being fully valid!
+impl Display for MSearch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            mx,
+            user_agent,
+            friendly_name,
+            uuid,
+        } = self;
+        writeln!(f, "M-SEARCH * HTTP/1.1")?;
+        writeln!(f, "HOST: 239.255.255.250:1900")?;
+        writeln!(f, r#"MAN: "ssdp:discover""#)?;
+        writeln!(f, "MX: {}", mx)?;
+        writeln!(f, "ST: ssdp:all")?;
+        if let Some(user_agent) = user_agent {
+            writeln!(f, "USER-AGENT: {}", user_agent)?;
+        }
+        writeln!(f, "CPFN.UPNP.ORG: {}", friendly_name)?;
+        if let Some(uuid) = uuid {
+            writeln!(f, "CPUUID.UPNP.ORG: {}", uuid)?;
+        }
+        writeln!(f)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct UserAgent {
     os: String,
@@ -59,7 +72,8 @@ struct UserAgent {
     product_version: Version,
 }
 
-/// As required by OCF spec (2015) for the *value*, does NOT include a header key
+/// Formatted as per OCF specification (2015) section 1.3.2 for the `USER-AGENT` *value*,
+/// does NOT include the header key
 impl Display for UserAgent {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -1,4 +1,7 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Display};
+
+use semver::Version;
+use uuid::Uuid;
 
 /// A valid & parsed ssdp message
 ///
@@ -7,6 +10,69 @@ use std::collections::HashMap;
 pub enum Message {
     /// NTS: ssdp:alive
     Alive(Notification),
+    /// MAN: ssdp:discover
+    Search(MSearch),
+}
+
+/// Formats Message as per SSDP specifications
+impl Display for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Message::Alive(_notification) => todo!(),
+            Message::Search(MSearch {
+                mx,
+                user_agent,
+                friendly_name,
+                uuid,
+            }) => {
+                writeln!(f, "M-SEARCH * HTTP/1.1")?;
+                writeln!(f, "HOST: 239.255.255.250:1900")?;
+                writeln!(f, r#"MAN: "ssdp:discover""#)?;
+                writeln!(f, "MX: {}", mx)?;
+                writeln!(f, "ST: ssdp:all")?;
+                if let Some(user_agent) = user_agent {
+                    writeln!(f, "USER-AGENT: {}", user_agent)?;
+                }
+                writeln!(f, "CPFN.UPNP.ORG: {}", friendly_name)?;
+                if let Some(uuid) = uuid {
+                    writeln!(f, "CPUUID.UPNP.ORG: {}", uuid)?;
+                }
+                writeln!(f)
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MSearch {
+    mx: u8,
+    user_agent: Option<UserAgent>,
+    friendly_name: String,
+    uuid: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct UserAgent {
+    os: String,
+    os_version: Version,
+    product_name: String,
+    product_version: Version,
+}
+
+/// As required by SSDP spec for the *value*, does NOT include a header key
+impl Display for UserAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            os,
+            os_version,
+            product_name,
+            product_version,
+        } = self;
+        write!(
+            f,
+            "{os}/{os_version} UPnP/2.0 {product_name}/{product_version}"
+        )
+    }
 }
 
 impl Message {
@@ -28,6 +94,30 @@ impl Message {
             return Some(Message::Alive(Notification { location, header }));
         }
         None
+    }
+
+    /// Construct a new M-SEARCH message
+    pub fn new_search(
+        mx: u8,
+        os: &str,
+        os_version: Version,
+        product_name: &str,
+        product_version: Version,
+        friendly_name: &str,
+        uuid: Uuid,
+    ) -> Self {
+        let user_agent = UserAgent {
+            os: os.to_string(),
+            os_version,
+            product_name: product_name.to_string(),
+            product_version,
+        };
+        Message::Search(MSearch {
+            mx,
+            user_agent: Some(user_agent),
+            friendly_name: friendly_name.to_string(),
+            uuid: Some(uuid),
+        })
     }
 }
 
@@ -121,13 +211,25 @@ ST: ssdp:all
 USER-AGENT: linux/6.6.87 UPnP/2.0 splurt/0.0.1
 CPFN.UPNP.ORG: splurt SSDP repeater
 CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003
+
 "#;
         let mx = 5;
         let os = "linux";
-        let os_version = Version::parse("6.6.87");
-        let user_agent = "splurt";
-        let user_agent_version = Version::parse("0.0.1");
+        let os_version = Version::parse("6.6.87").expect("os_version");
+        let product_name = "splurt";
+        let product_version = Version::parse("0.0.1").expect("product_version");
         let friendly_name = "splurt SSDP repeater";
         let uuid = uuid!("2fac1234-31f8-11b4-a222-08002b34c003");
+        let msg = Message::new_search(
+            mx,
+            os,
+            os_version,
+            product_name,
+            product_version,
+            friendly_name,
+            uuid,
+        );
+        let msg_text = msg.to_string();
+        assert_eq!(msg_text, expected);
     }
 }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -117,7 +117,10 @@ impl Message {
         None
     }
 
-    /// Construct a new M-SEARCH message
+    /// Construct a new M-SEARCH message.
+    ///
+    /// While details of the user agent are technically optional we are going to include them
+    /// in our searches.
     pub fn new_search(
         mx: u8,
         os: &str,

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -9,7 +9,6 @@
 
 use std::{collections::HashMap, fmt::Display};
 
-use semver::Version;
 use uuid::Uuid;
 
 /// A valid & parsed ssdp message
@@ -76,9 +75,9 @@ impl Display for MSearch {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct UserAgent {
     os: String,
-    os_version: Version,
+    os_version: String,
     product_name: String,
-    product_version: Version,
+    product_version: String,
 }
 
 /// Formatted as per OCF specification (2020) section 1.3.2 for the `USER-AGENT` *value*,
@@ -126,17 +125,17 @@ impl Message {
     pub fn new_search(
         mx: u8,
         os: &str,
-        os_version: Version,
+        os_version: &str,
         product_name: &str,
-        product_version: Version,
+        product_version: &str,
         friendly_name: &str,
         uuid: Uuid,
     ) -> Self {
         let user_agent = UserAgent {
             os: os.to_string(),
-            os_version,
+            os_version: os_version.to_string(),
             product_name: product_name.to_string(),
-            product_version,
+            product_version: product_version.to_string(),
         };
         Message::Search(MSearch {
             mx,
@@ -160,7 +159,6 @@ type RawHeader = HashMap<String, String>;
 
 #[cfg(test)]
 mod tests {
-    use semver::Version;
     use uuid::uuid;
 
     use super::*;
@@ -241,9 +239,9 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003
 "#;
         let mx = 5;
         let os = "linux";
-        let os_version = Version::parse("6.6.87").expect("os_version");
+        let os_version = "6.6.87";
         let product_name = "splurt";
-        let product_version = Version::parse("0.0.1").expect("product_version");
+        let product_version = "0.0.1";
         let friendly_name = "splurt SSDP repeater";
         let uuid = uuid!("2fac1234-31f8-11b4-a222-08002b34c003");
         let msg = Message::new_search(

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -44,6 +44,9 @@ type RawHeader = HashMap<String, String>;
 
 #[cfg(test)]
 mod tests {
+    use semver::Version;
+    use uuid::uuid;
+
     use super::*;
 
     #[cfg(assert_matches_in_root)]
@@ -106,5 +109,25 @@ name: my_bulb
             header: alive_header,
         };
         assert_matches!(msg, Message::Alive(notification) if notification == expected_notification);
+    }
+
+    #[test]
+    fn generate_search() {
+        let expected = r#"M-SEARCH * HTTP/1.1
+HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 5
+ST: ssdp:all
+USER-AGENT: linux/6.6.87 UPnP/2.0 splurt/0.0.1
+CPFN.UPNP.ORG: splurt SSDP repeater
+CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003
+"#;
+        let mx = 5;
+        let os = "linux";
+        let os_version = Version::parse("6.6.87");
+        let user_agent = "splurt";
+        let user_agent_version = Version::parse("0.0.1");
+        let friendly_name = "splurt SSDP repeater";
+        let uuid = uuid!("2fac1234-31f8-11b4-a222-08002b34c003");
     }
 }

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -1,7 +1,7 @@
 //! An SSDP searcher, that sends M-SEARCH and receives NOTIFY responses
 //!
 //! ## Example usage
-//! ```
+//! ```no_run no reply possible
 //! # use std::io;
 //! use ssdp_rs::search::Searcher;
 //!
@@ -13,7 +13,7 @@
 //! # futures::executor::block_on( async {
 //! searcher.search().await.expect("search executed");
 //! # });
-//! 
+//!
 //! // get the results
 //! # futures::executor::block_on(
 //! async {
@@ -30,9 +30,10 @@
 use std::{
     io,
     net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+    task::Poll,
 };
 
-use futures::FutureExt;
+use futures::{FutureExt, ready};
 use uuid::Uuid;
 
 use crate::{message::Message, udp::UdpStream};
@@ -96,7 +97,7 @@ impl Searcher {
     }
 
     pub fn next<'s>(&'s mut self) -> Next<'s> {
-        todo!("next")
+        Next { searcher: self }
     }
 }
 
@@ -108,8 +109,22 @@ pub struct Next<'searcher> {
 impl<'searcher> Future for Next<'searcher> {
     type Output = Option<io::Result<(String, SocketAddr)>>;
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
-        todo!()
+    fn poll(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
+        let this = &mut *self;
+        let searcher = &mut *this.searcher;
+        let stream = &mut searcher.stream;
+        let reply = ready!(stream.next().poll_unpin(cx));
+        match reply {
+            Some(reply) => {
+                let (reply, _, sender) = reply?;
+                let reply = String::from_utf8_lossy(&reply).to_string();
+                Poll::Ready(Some(Ok((reply, sender))))
+            }
+            None => Poll::Ready(None),
+        }
     }
 }
 

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -1,1 +1,32 @@
 //! An SSDP searcher, that sends M-SEARCH and receives NOTIFY responses
+//!
+//! ## Example usage
+//! ```
+//! use ssdp_rs::search::Searcher;
+//!
+//! // Create a new searcher
+//! let searcher = Searcher::new();
+//!
+//! // run a search - can call next().await on the result
+//! // let some_sort_of_iterable_or_stream = searcher.search().await;
+//! ```
+
+use std::{
+    io,
+    net::{Ipv4Addr, SocketAddrV4},
+};
+
+use crate::udp::UdpStream;
+
+pub struct Searcher {
+    stream: UdpStream,
+}
+
+impl Searcher {
+    pub fn new() -> io::Result<Self> {
+        let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 1900).into();
+        Ok(Searcher {
+            stream: UdpStream::bind(addr)?,
+        })
+    }
+}

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -142,7 +142,7 @@ impl<'searcher> Future for Search<'searcher> {
         let this = &mut *self;
         let stream = &mut *this.searcher;
         let msg = this.msg.as_bytes();
-        let ssdp_multicast = Ipv4Addr::new(239, 25, 255, 25);
+        let ssdp_multicast = Ipv4Addr::new(239, 255, 255, 250);
         let ssdp_multicast = SocketAddr::new(ssdp_multicast.into(), 1900);
         stream
             .push(msg, ssdp_multicast)

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -2,13 +2,20 @@
 //!
 //! ## Example usage
 //! ```
+//! # use std::io;
 //! use ssdp_rs::search::Searcher;
 //!
+//! # fn main() -> io::Result<()> {
 //! // Create a new searcher
-//! let searcher = Searcher::new("splurt", "0.0.1", "splurt ssdp message repeater");
+//! let searcher = Searcher::new("splurt", "0.0.1", "splurt ssdp message repeater")?;
 //!
 //! // run a search - can call next().await on the result
+//! futures::executor::block_on( async {
+//!     let some_sort_of_iterable_or_stream = searcher.search().await;
+//! });
 //! // let some_sort_of_iterable_or_stream = searcher.search().await;
+//! # Ok(())
+//! # }
 //! ```
 
 use std::{
@@ -49,5 +56,20 @@ impl Searcher {
             friendly_name: friendly_name.to_string(),
             uuid,
         })
+    }
+
+    pub fn search(&self) -> Search {
+        todo!("search")
+    }
+}
+
+/// The future returned by [Searcher::search]
+pub struct Search;
+
+impl Future for Search {
+    type Output = ();
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        todo!("poll search")
     }
 }

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -1,7 +1,8 @@
 //! An SSDP searcher, that sends M-SEARCH and receives NOTIFY responses
 //!
 //! ## Example usage
-//! ```no_run no reply possible
+//! ```no_run
+//! # // no reply possible so not run as test to avoid endless loop
 //! # use std::io;
 //! use ssdp_rs::search::Searcher;
 //!

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -25,7 +25,7 @@ use std::{
 
 use uuid::Uuid;
 
-use crate::udp::UdpStream;
+use crate::{message::Message, udp::UdpStream};
 
 #[derive(Debug)]
 pub struct Searcher {
@@ -59,19 +59,46 @@ impl Searcher {
     }
 
     pub fn search<'s>(&'s mut self) -> Search<'s> {
-        Search { searcher: self }
+        let Searcher {
+            stream,
+            mx,
+            os,
+            os_version,
+            product_name,
+            product_version,
+            friendly_name,
+            uuid,
+        } = self;
+        let msg = Message::new_search(
+            *mx,
+            os,
+            os_version,
+            product_name,
+            product_version,
+            friendly_name,
+            *uuid,
+        )
+        .to_string();
+        Search {
+            searcher: stream,
+            msg,
+        }
     }
 }
 
 /// The future returned by [Searcher::search]
 pub struct Search<'searcher> {
-    searcher: &'searcher mut Searcher,
+    searcher: &'searcher mut UdpStream,
+    msg: String,
 }
 
 impl<'searcher> Future for Search<'searcher> {
     type Output = io::Result<()>;
 
-    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+    fn poll(
+        self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Self::Output> {
         todo!("poll search")
     }
 }

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -13,7 +13,16 @@
 //! # futures::executor::block_on( async {
 //! searcher.search().await.expect("search executed");
 //! # });
-//! // let some_sort_of_iterable_or_stream = searcher.search().await;
+//! 
+//! // get the results
+//! # futures::executor::block_on(
+//! async {
+//!     loop {
+//!         let answer = searcher.next().await;
+//!         // do something with answer
+//!     }
+//! }
+//! # );
 //! # Ok(())
 //! # }
 //! ```
@@ -84,6 +93,23 @@ impl Searcher {
             searcher: stream,
             msg,
         }
+    }
+
+    pub fn next<'s>(&'s mut self) -> Next<'s> {
+        todo!("next")
+    }
+}
+
+/// The future returned by [Searcher::next]
+pub struct Next<'searcher> {
+    searcher: &'searcher mut Searcher,
+}
+
+impl<'searcher> Future for Next<'searcher> {
+    type Output = Option<io::Result<(String, SocketAddr)>>;
+
+    fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
+        todo!()
     }
 }
 

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -7,11 +7,11 @@
 //!
 //! # fn main() -> io::Result<()> {
 //! // Create a new searcher
-//! let searcher = Searcher::new("splurt", "0.0.1", "splurt ssdp message repeater")?;
+//! let mut searcher = Searcher::new("splurt", "0.0.1", "splurt ssdp message repeater")?;
 //!
 //! // run a search - can call next().await on the result
 //! futures::executor::block_on( async {
-//!     let some_sort_of_iterable_or_stream = searcher.search().await;
+//!     searcher.search().await.expect("search executed");
 //! });
 //! // let some_sort_of_iterable_or_stream = searcher.search().await;
 //! # Ok(())
@@ -58,16 +58,18 @@ impl Searcher {
         })
     }
 
-    pub fn search(&self) -> Search {
-        todo!("search")
+    pub fn search<'s>(&'s mut self) -> Search<'s> {
+        Search { searcher: self }
     }
 }
 
 /// The future returned by [Searcher::search]
-pub struct Search;
+pub struct Search<'searcher> {
+    searcher: &'searcher mut Searcher,
+}
 
-impl Future for Search {
-    type Output = ();
+impl<'searcher> Future for Search<'searcher> {
+    type Output = io::Result<()>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
         todo!("poll search")

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -38,7 +38,7 @@ use crate::{message::Message, udp::UdpStream};
 
 #[derive(Debug)]
 pub struct Searcher {
-    stream: UdpStream,
+    stream: UdpStream<512>,
     mx: u8,
     os: String,
     os_version: String,
@@ -128,7 +128,7 @@ impl<'searcher> Future for Next<'searcher> {
 
 /// The future returned by [Searcher::search]
 pub struct Search<'searcher> {
-    searcher: &'searcher mut UdpStream,
+    searcher: &'searcher mut UdpStream<512>,
     msg: String,
 }
 

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -5,7 +5,7 @@
 //! use ssdp_rs::search::Searcher;
 //!
 //! // Create a new searcher
-//! let searcher = Searcher::new();
+//! let searcher = Searcher::new("splurt", "0.0.1", "splurt ssdp message repeater");
 //!
 //! // run a search - can call next().await on the result
 //! // let some_sort_of_iterable_or_stream = searcher.search().await;
@@ -16,17 +16,38 @@ use std::{
     net::{Ipv4Addr, SocketAddrV4},
 };
 
+use uuid::Uuid;
+
 use crate::udp::UdpStream;
 
+#[derive(Debug)]
 pub struct Searcher {
     stream: UdpStream,
+    mx: u8,
+    os: String,
+    os_version: String,
+    product_name: String,
+    product_version: String,
+    friendly_name: String,
+    uuid: Uuid,
 }
 
 impl Searcher {
-    pub fn new() -> io::Result<Self> {
+    pub fn new(product_name: &str, product_version: &str, friendly_name: &str) -> io::Result<Self> {
         let addr = SocketAddrV4::new(Ipv4Addr::UNSPECIFIED, 1900).into();
+        let uuid = Uuid::new_v4();
+        let os_info = osinfo::get();
+        let os = os_info.get_name();
+        let os_version = os_info.get_version().to_string();
         Ok(Searcher {
             stream: UdpStream::bind(addr)?,
+            mx: 5,
+            os,
+            os_version,
+            product_name: product_name.to_string(),
+            product_version: product_version.into(),
+            friendly_name: friendly_name.to_string(),
+            uuid,
         })
     }
 }

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -15,14 +15,12 @@
 //! # });
 //!
 //! // get the results
-//! # futures::executor::block_on(
-//! async {
-//!     loop {
-//!         let answer = searcher.next().await;
-//!         // do something with answer
-//!     }
+//! # futures::executor::block_on( async {
+//! loop {
+//!     let answer = searcher.next().await;
+//!     // do something with answer
 //! }
-//! # );
+//! # });
 //! # Ok(())
 //! # }
 //! ```

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -20,9 +20,10 @@
 
 use std::{
     io,
-    net::{Ipv4Addr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
 };
 
+use futures::FutureExt;
 use uuid::Uuid;
 
 use crate::{message::Message, udp::UdpStream};
@@ -96,9 +97,14 @@ impl<'searcher> Future for Search<'searcher> {
     type Output = io::Result<()>;
 
     fn poll(
-        self: std::pin::Pin<&mut Self>,
+        mut self: std::pin::Pin<&mut Self>,
         cx: &mut std::task::Context<'_>,
     ) -> std::task::Poll<Self::Output> {
-        todo!("poll search")
+        let this = &mut *self;
+        let stream = &mut *this.searcher;
+        let msg = this.msg.as_bytes();
+        let ssdp_multicast = Ipv4Addr::new(239, 25, 255, 25);
+        let ssdp_multicast = SocketAddr::new(ssdp_multicast.into(), 1900);
+        stream.push(msg, ssdp_multicast).poll_unpin(cx).map_ok(|_| ())
     }
 }

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -1,0 +1,1 @@
+//! An SSDP searcher, that sends M-SEARCH and receives NOTIFY responses

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -10,9 +10,9 @@
 //! let mut searcher = Searcher::new("splurt", "0.0.1", "splurt ssdp message repeater")?;
 //!
 //! // run a search - can call next().await on the result
-//! futures::executor::block_on( async {
-//!     searcher.search().await.expect("search executed");
-//! });
+//! # futures::executor::block_on( async {
+//! searcher.search().await.expect("search executed");
+//! # });
 //! // let some_sort_of_iterable_or_stream = searcher.search().await;
 //! # Ok(())
 //! # }
@@ -105,6 +105,9 @@ impl<'searcher> Future for Search<'searcher> {
         let msg = this.msg.as_bytes();
         let ssdp_multicast = Ipv4Addr::new(239, 25, 255, 25);
         let ssdp_multicast = SocketAddr::new(ssdp_multicast.into(), 1900);
-        stream.push(msg, ssdp_multicast).poll_unpin(cx).map_ok(|_| ())
+        stream
+            .push(msg, ssdp_multicast)
+            .poll_unpin(cx)
+            .map_ok(|_| ())
     }
 }

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -17,7 +17,16 @@ use socket2::{Domain, Type};
 #[derive(Debug)]
 /// A non-blocking async UdpSocket with ability to `recv_from` via `next` and `send_to` via `push`.
 ///
-/// Messages received via [UdpStream::next] will be provided as an array of bytes of length `SIZE`.
+/// #### BUF_SIZE
+/// Messages received via [UdpStream::next] will be provided as an array of bytes of length
+/// `BUF_SIZE`. This is a generic const to allow avoid us having to allocate a 65k buffer on each
+/// call to next in order to cover the max possible UDP datagram size.
+///
+/// It is your responsibility to ensure that `BUF_SIZE` is large enough to hold the largest UDP
+/// datagram your protocol expects; if it is smaller than the incoming datagram size, the datagram
+/// will be truncated in the output from `next`. You cannot rely on the returned `bytes_read` value
+/// to indicate truncation as this will also be set to the buffer length, not the full size of the
+/// truncated message (this is the underlying behaviour of the libc call `recv_from`).
 ///
 /// #### Note
 /// - This does NOT have exclusive access to the bound port. If you want to guarantee that
@@ -566,5 +575,33 @@ mod tests {
         let first = UdpStream::<32>::bind(addr).expect("first connection");
         let addr = first.local_addr().expect("bound port");
         let _second = UdpStream::<32>::bind(addr).expect("second connection");
+    }
+
+    #[futures_net::test]
+    async fn truncated_next() {
+        let loopback = Ipv4Addr::new(127, 0, 0, 1);
+        let addr: SocketAddr = SocketAddrV4::new(loopback, 0).into();
+        let mut receiver = UdpStream::<8>::bind(addr).expect("receiver");
+        let rec_addr = receiver.local_addr().expect("bound port");
+
+        let mut sender = UdpStream::<8>::bind(addr).expect("sender");
+        let original_msg = b"udp loopback test";
+
+        let send = async move {
+            sender.push(original_msg, rec_addr).await.expect("send msg");
+        };
+
+        let rec = async {
+            let (msg, len, _sent_by) = receiver
+                .next()
+                .await
+                .expect("a message")
+                .expect("a valid message");
+            // bytes read is limited to buf size - as per libc call recv_from
+            assert_eq!(len, 8);
+            assert_eq!(msg, original_msg[..8]);
+        };
+
+        futures::join!(rec, send);
     }
 }

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -118,7 +118,7 @@ impl<const BUF_SIZE: usize> UdpStream<BUF_SIZE> {
     /// `Option<io::Result<([u8; BUF_SIZE], usize, SocketAddr)>>`
     ///
     /// #### Note
-    /// 
+    ///
     /// - Messages received via [UdpStream::next] will be provided as an array of bytes of length
     ///   `BUF_SIZE`. This is a generic const to allow avoid us having to allocate a 65k buffer on each
     ///   call to next in order to cover the max possible UDP datagram size.

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -115,12 +115,20 @@ impl<const BUF_SIZE: usize> UdpStream<BUF_SIZE> {
     ///
     /// Awaiting returns an array of bytes containing the message received, the message length
     /// and the target from whence the data came as an
-    /// `Option<io::Result<([u8; 65507], usize, SocketAddr)>>`
+    /// `Option<io::Result<([u8; BUF_SIZE], usize, SocketAddr)>>`
     ///
     /// #### Note
-    /// - The message buffer is sized to the max practical size of a UDP Datagram. All bytes after
-    ///   the actual message will be NULL so it can be directly converted to a String, for example
-    ///   without first slicing. Other data manipulation should take into account the actual length.
+    /// 
+    /// - Messages received via [UdpStream::next] will be provided as an array of bytes of length
+    ///   `BUF_SIZE`. This is a generic const to allow avoid us having to allocate a 65k buffer on each
+    ///   call to next in order to cover the max possible UDP datagram size.
+    /// - It is your responsibility to ensure that `BUF_SIZE` is large enough to hold the largest UDP
+    ///   datagram your protocol expects; if it is smaller than the incoming datagram size, the datagram
+    ///   will be truncated in the output from `next`. You cannot rely on the returned `bytes_read` value
+    ///   to indicate truncation as this will also be set to the buffer length, not the full size of the
+    ///   truncated message (this is the underlying behaviour of the libc call `recv_from`).
+    /// - All bytes after the actual message will be NULL so it can be directly converted to a String,
+    ///   for example, without first slicing. Other data manipulation should take into account the actual length.
     /// - There are no clear situations which could lead to this returning `None`. Wrapping the
     ///   returned data in an `Option` is done purely to maintain a consistent API with expectations
     ///   on an Iterator / Stream

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -17,10 +17,12 @@ use socket2::{Domain, Type};
 #[derive(Debug)]
 /// A non-blocking async UdpSocket with ability to `recv_from` via `next` and `send_to` via `push`.
 ///
+/// Messages received via [UdpStream::next] will be provided as an array of bytes of length `SIZE`.
+///
 /// #### Note
 /// This does NOT have exclusive access to the bound port. If you want to guarantee that no other
 /// processes bind to the same socket use a [UdpConnectedStream], which will exclusively claim the port.
-pub struct UdpStream {
+pub struct UdpStream<const SIZE: usize> {
     /// The underlying, evented Socket.
     ///
     /// #### Note
@@ -33,7 +35,7 @@ pub struct UdpStream {
     io: PollEvented<sys::net::UdpSocket>,
 }
 
-impl UdpStream {
+impl<const SIZE: usize> UdpStream<SIZE> {
     /// Create a new [UdpStream] by binding it to a given [SocketAddr].
     ///
     /// The listener is guaranteed to be constructed to be non-blocking and have non-exclusive
@@ -84,7 +86,7 @@ impl UdpStream {
     pub fn recv_from<'listener, 'buf>(
         &'listener mut self,
         buf: &'buf mut [u8],
-    ) -> RecvFrom<'listener, 'buf> {
+    ) -> RecvFrom<'listener, 'buf, SIZE> {
         RecvFrom {
             buf,
             listener: self,
@@ -104,7 +106,7 @@ impl UdpStream {
     /// - There are no clear situations which could lead to this returning `None`. Wrapping the
     ///   returned data in an `Option` is done purely to maintain a consistent API with expectations
     ///   on an Iterator / Stream
-    pub fn next<'s>(&'s mut self) -> Next<'s> {
+    pub fn next<'s>(&'s mut self) -> Next<'s, SIZE> {
         Next { stream: self }
     }
 
@@ -120,7 +122,7 @@ impl UdpStream {
         &'s mut self,
         buf: &'b [u8],
         addr: A,
-    ) -> Push<'s, 'b, A> {
+    ) -> Push<'s, 'b, A, SIZE> {
         Push {
             stream: self,
             buf,
@@ -131,13 +133,15 @@ impl UdpStream {
 
 /// The future returned by [UdpStream::push]
 #[derive(Debug)]
-pub struct Push<'stream, 'buf, A: ToSocketAddrs + Unpin> {
-    stream: &'stream mut UdpStream,
+pub struct Push<'stream, 'buf, A: ToSocketAddrs + Unpin, const SIZE: usize> {
+    stream: &'stream mut UdpStream<SIZE>,
     buf: &'buf [u8],
     addr: A,
 }
 
-impl<'stream, 'buf, A: ToSocketAddrs + Unpin> Future for Push<'stream, 'buf, A> {
+impl<'stream, 'buf, A: ToSocketAddrs + Unpin, const SIZE: usize> Future
+    for Push<'stream, 'buf, A, SIZE>
+{
     type Output = io::Result<usize>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -169,12 +173,12 @@ impl<'stream, 'buf, A: ToSocketAddrs + Unpin> Future for Push<'stream, 'buf, A> 
 
 /// The future returned by [UdpStream::next]
 #[derive(Debug)]
-pub struct Next<'stream> {
-    stream: &'stream mut UdpStream,
+pub struct Next<'stream, const SIZE: usize> {
+    stream: &'stream mut UdpStream<SIZE>,
 }
 
-impl<'stream> Future for Next<'stream> {
-    type Output = Option<io::Result<([u8; 65507], usize, SocketAddr)>>;
+impl<'stream, const SIZE: usize> Future for Next<'stream, SIZE> {
+    type Output = Option<io::Result<([u8; SIZE], usize, SocketAddr)>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = &mut *self;
@@ -185,7 +189,7 @@ impl<'stream> Future for Next<'stream> {
 
         // Maximum data length for a UDP Datagram
         // see https://en.wikipedia.org/wiki/User_Datagram_Protocol#UDP_datagram_structure
-        let mut buf: [u8; 65507] = [b'\x00'; 65507];
+        let mut buf: [u8; SIZE] = [b'\x00'; SIZE];
 
         let result = socket
             .recv_from(&mut buf)
@@ -205,12 +209,12 @@ impl<'stream> Future for Next<'stream> {
 
 /// The future returned by `UdpStream::recv_from`
 #[derive(Debug)]
-pub struct RecvFrom<'listener, 'buf> {
-    listener: &'listener mut UdpStream,
+pub struct RecvFrom<'listener, 'buf, const SIZE: usize> {
+    listener: &'listener mut UdpStream<SIZE>,
     buf: &'buf mut [u8],
 }
 
-impl<'listener, 'buf> Future for RecvFrom<'listener, 'buf> {
+impl<'listener, 'buf, const SIZE: usize> Future for RecvFrom<'listener, 'buf, SIZE> {
     type Output = io::Result<(usize, SocketAddr)>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -220,7 +224,7 @@ impl<'listener, 'buf> Future for RecvFrom<'listener, 'buf> {
 }
 
 /// Private functions for handling readiness to read.
-impl UdpStream {
+impl<const SIZE: usize> UdpStream<SIZE> {
     /// Receives data from the IO interface if it is ready to read.
     ///
     /// If successful, returns the number of bytes read and the target from whence the data came.
@@ -267,7 +271,7 @@ impl UdpStream {
     }
 }
 
-impl AsyncReadReady for UdpStream {
+impl<const SIZE: usize> AsyncReadReady for UdpStream<SIZE> {
     type Ok = Ready;
 
     type Err = io::Error;
@@ -280,7 +284,7 @@ impl AsyncReadReady for UdpStream {
     }
 }
 
-impl AsyncWriteReady for UdpStream {
+impl<const SIZE: usize> AsyncWriteReady for UdpStream<SIZE> {
     type Ok = Ready;
 
     type Err = io::Error;
@@ -550,8 +554,8 @@ mod tests {
     async fn non_blocking() {
         let loopback = Ipv4Addr::new(127, 0, 0, 1);
         let addr: SocketAddr = SocketAddrV4::new(loopback, 0).into();
-        let first = UdpStream::bind(addr).expect("first connection");
+        let first = UdpStream::<32>::bind(addr).expect("first connection");
         let addr = first.local_addr().expect("bound port");
-        let _second = UdpStream::bind(addr).expect("second connection");
+        let _second = UdpStream::<32>::bind(addr).expect("second connection");
     }
 }

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -64,6 +64,13 @@ impl<const SIZE: usize> UdpStream<SIZE> {
         Ok(Self { io })
     }
 
+    // // TODO: #22 Add bind_exclusive constructor & update struct docs for UdpStream
+    // pub fn bind_exclusive(addr: SocketAddr) -> io::Result<Self>
+    // pub fn is_exclusive(&self) -> Option<SocketAddr>
+    // pub fn check_exclusive(&self) -> io::Result<SocketAddr>
+    // pub fn is_non_exclusive(&self) -> Option<SocketAddr>
+    // pub fn check_non_exclusive(&self) -> io::Result<SocketAddr>
+
     /// Get the local address of this listener
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         let io = &self.io;

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -49,11 +49,11 @@ impl<const SIZE: usize> UdpStream<SIZE> {
         s2.nonblocking()?
             .ok_or(io::Error::from(io::ErrorKind::Unsupported))?;
 
-        // NOTE for consideration if/when implementing conversion to a UdpStream
-        // =====================================================================
-        // This would stop another process from re-binding to the same address & port if converted
-        // to a UdpStream which actively begins listening on this address, thereby claiming
-        // exclusive interest in all received data.
+        // NOTE for consideration if/when implementing conversion to a UdpConnectedStream
+        // ==============================================================================
+        // This would stop another process from re-binding to the same address *& port* if
+        // converted to a UdpConnectedStream which actively begins listening on this address,
+        // thereby claiming exclusive interest in all received data.
         // see https://man7.org/linux/man-pages/man7/socket.7.html#:~:text=SO_REUSEADDR
         s2.set_reuse_address(true)?;
         s2.reuse_address()?

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -20,8 +20,9 @@ use socket2::{Domain, Type};
 /// Messages received via [UdpStream::next] will be provided as an array of bytes of length `SIZE`.
 ///
 /// #### Note
-/// This does NOT have exclusive access to the bound port. If you want to guarantee that no other
-/// processes bind to the same socket use a [UdpConnectedStream], which will exclusively claim the port.
+/// - This does NOT have exclusive access to the bound port. If you want to guarantee that
+///   no other processes bind to the same socket use a [UdpConnectedStream], which will exclusively
+///   claim the port (or vote thumbs up on issue #22 TODO: implement `bind_exclusive` etc.)
 pub struct UdpStream<const BUF_SIZE: usize> {
     /// The underlying, evented Socket.
     ///

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -22,7 +22,7 @@ use socket2::{Domain, Type};
 /// #### Note
 /// This does NOT have exclusive access to the bound port. If you want to guarantee that no other
 /// processes bind to the same socket use a [UdpConnectedStream], which will exclusively claim the port.
-pub struct UdpStream<const SIZE: usize> {
+pub struct UdpStream<const BUF_SIZE: usize> {
     /// The underlying, evented Socket.
     ///
     /// #### Note
@@ -36,7 +36,7 @@ pub struct UdpStream<const SIZE: usize> {
     io: PollEvented<sys::net::UdpSocket>,
 }
 
-impl<const SIZE: usize> UdpStream<SIZE> {
+impl<const BUF_SIZE: usize> UdpStream<BUF_SIZE> {
     /// Create a new [UdpStream] by binding it to a given [SocketAddr].
     ///
     /// The listener is guaranteed to be constructed to be non-blocking and have non-exclusive
@@ -94,7 +94,7 @@ impl<const SIZE: usize> UdpStream<SIZE> {
     pub fn recv_from<'listener, 'buf>(
         &'listener mut self,
         buf: &'buf mut [u8],
-    ) -> RecvFrom<'listener, 'buf, SIZE> {
+    ) -> RecvFrom<'listener, 'buf, BUF_SIZE> {
         RecvFrom {
             buf,
             listener: self,
@@ -114,7 +114,7 @@ impl<const SIZE: usize> UdpStream<SIZE> {
     /// - There are no clear situations which could lead to this returning `None`. Wrapping the
     ///   returned data in an `Option` is done purely to maintain a consistent API with expectations
     ///   on an Iterator / Stream
-    pub fn next<'s>(&'s mut self) -> Next<'s, SIZE> {
+    pub fn next<'s>(&'s mut self) -> Next<'s, BUF_SIZE> {
         Next { stream: self }
     }
 
@@ -130,7 +130,7 @@ impl<const SIZE: usize> UdpStream<SIZE> {
         &'s mut self,
         buf: &'b [u8],
         addr: A,
-    ) -> Push<'s, 'b, A, SIZE> {
+    ) -> Push<'s, 'b, A, BUF_SIZE> {
         Push {
             stream: self,
             buf,
@@ -141,14 +141,14 @@ impl<const SIZE: usize> UdpStream<SIZE> {
 
 /// The future returned by [UdpStream::push]
 #[derive(Debug)]
-pub struct Push<'stream, 'buf, A: ToSocketAddrs + Unpin, const SIZE: usize> {
-    stream: &'stream mut UdpStream<SIZE>,
+pub struct Push<'stream, 'buf, A: ToSocketAddrs + Unpin, const _BUF_SIZE: usize> {
+    stream: &'stream mut UdpStream<_BUF_SIZE>,
     buf: &'buf [u8],
     addr: A,
 }
 
-impl<'stream, 'buf, A: ToSocketAddrs + Unpin, const SIZE: usize> Future
-    for Push<'stream, 'buf, A, SIZE>
+impl<'stream, 'buf, A: ToSocketAddrs + Unpin, const _BS: usize> Future
+    for Push<'stream, 'buf, A, _BS>
 {
     type Output = io::Result<usize>;
 
@@ -181,12 +181,12 @@ impl<'stream, 'buf, A: ToSocketAddrs + Unpin, const SIZE: usize> Future
 
 /// The future returned by [UdpStream::next]
 #[derive(Debug)]
-pub struct Next<'stream, const SIZE: usize> {
-    stream: &'stream mut UdpStream<SIZE>,
+pub struct Next<'stream, const BUF_SIZE: usize> {
+    stream: &'stream mut UdpStream<BUF_SIZE>,
 }
 
-impl<'stream, const SIZE: usize> Future for Next<'stream, SIZE> {
-    type Output = Option<io::Result<([u8; SIZE], usize, SocketAddr)>>;
+impl<'stream, const BUF_SIZE: usize> Future for Next<'stream, BUF_SIZE> {
+    type Output = Option<io::Result<([u8; BUF_SIZE], usize, SocketAddr)>>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = &mut *self;
@@ -197,7 +197,7 @@ impl<'stream, const SIZE: usize> Future for Next<'stream, SIZE> {
 
         // Maximum data length for a UDP Datagram
         // see https://en.wikipedia.org/wiki/User_Datagram_Protocol#UDP_datagram_structure
-        let mut buf: [u8; SIZE] = [b'\x00'; SIZE];
+        let mut buf: [u8; BUF_SIZE] = [b'\x00'; BUF_SIZE];
 
         let result = socket
             .recv_from(&mut buf)
@@ -217,12 +217,12 @@ impl<'stream, const SIZE: usize> Future for Next<'stream, SIZE> {
 
 /// The future returned by `UdpStream::recv_from`
 #[derive(Debug)]
-pub struct RecvFrom<'listener, 'buf, const SIZE: usize> {
-    listener: &'listener mut UdpStream<SIZE>,
+pub struct RecvFrom<'listener, 'buf, const _BUF_SIZE: usize> {
+    listener: &'listener mut UdpStream<_BUF_SIZE>,
     buf: &'buf mut [u8],
 }
 
-impl<'listener, 'buf, const SIZE: usize> Future for RecvFrom<'listener, 'buf, SIZE> {
+impl<'listener, 'buf, const _BS: usize> Future for RecvFrom<'listener, 'buf, _BS> {
     type Output = io::Result<(usize, SocketAddr)>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -232,7 +232,7 @@ impl<'listener, 'buf, const SIZE: usize> Future for RecvFrom<'listener, 'buf, SI
 }
 
 /// Private functions for handling readiness to read.
-impl<const SIZE: usize> UdpStream<SIZE> {
+impl<const BUF_SIZE: usize> UdpStream<BUF_SIZE> {
     /// Receives data from the IO interface if it is ready to read.
     ///
     /// If successful, returns the number of bytes read and the target from whence the data came.
@@ -279,7 +279,7 @@ impl<const SIZE: usize> UdpStream<SIZE> {
     }
 }
 
-impl<const SIZE: usize> AsyncReadReady for UdpStream<SIZE> {
+impl<const _BUF_SIZE: usize> AsyncReadReady for UdpStream<_BUF_SIZE> {
     type Ok = Ready;
 
     type Err = io::Error;
@@ -292,7 +292,7 @@ impl<const SIZE: usize> AsyncReadReady for UdpStream<SIZE> {
     }
 }
 
-impl<const SIZE: usize> AsyncWriteReady for UdpStream<SIZE> {
+impl<const _BUF_SIZE: usize> AsyncWriteReady for UdpStream<_BUF_SIZE> {
     type Ok = Ready;
 
     type Err = io::Error;

--- a/ssdp-rs/src/udp.rs
+++ b/ssdp-rs/src/udp.rs
@@ -30,8 +30,9 @@ pub struct UdpStream<const SIZE: usize> {
     ///   and is NOT the same type as stored here.
     /// - [`futures_net::driver::sys::net::UdpSocket`] is not actually non-blocking, despite the
     ///   documentation.
-    /// - Neither [std::sys::net::UdpSocket], nor [net2::UdpBuilder] expose`set_nonblocking()` so
-    ///   we need use [socket2::Socket] while building the listener.
+    /// - Neither [std::sys::net::UdpSocket], nor [net2::UdpBuilder] expose `set_nonblocking()` so
+    ///   we need use [socket2::Socket] while building the listener but are unable to change
+    ///   blocking or exclusivity after construction.
     io: PollEvented<sys::net::UdpSocket>,
 }
 
@@ -50,7 +51,7 @@ impl<const SIZE: usize> UdpStream<SIZE> {
 
         // NOTE for consideration if/when implementing conversion to a UdpStream
         // =====================================================================
-        // This would still another process from re-binding to the same address & port if converted
+        // This would stop another process from re-binding to the same address & port if converted
         // to a UdpStream which actively begins listening on this address, thereby claiming
         // exclusive interest in all received data.
         // see https://man7.org/linux/man-pages/man7/socket.7.html#:~:text=SO_REUSEADDR

--- a/ssdp-rs/tests/loopback.rs
+++ b/ssdp-rs/tests/loopback.rs
@@ -62,7 +62,7 @@ async fn udp() {
     // The port allocated can be queried via the TcpListener::local_addr method.
     let addr: SocketAddr = SocketAddrV4::new(loopback, 0).into();
 
-    let mut receiver = UdpStream::bind(addr).expect("receiver");
+    let mut receiver = UdpStream::<32>::bind(addr).expect("receiver");
     let rec_addr = receiver.local_addr().expect("bound port");
     dbg!(rec_addr);
 
@@ -116,7 +116,7 @@ async fn next_to_read() {
     // The port allocated can be queried via the TcpListener::local_addr method.
     let addr: SocketAddr = SocketAddrV4::new(loopback, 0).into();
 
-    let mut receiver = UdpStream::bind(addr).expect("receiver");
+    let mut receiver = UdpStream::<32>::bind(addr).expect("receiver");
     let rec_addr = receiver.local_addr().expect("bound port");
     dbg!(rec_addr);
 
@@ -172,11 +172,11 @@ async fn push_to_send() {
     // The port allocated can be queried via the TcpListener::local_addr method.
     let addr: SocketAddr = SocketAddrV4::new(loopback, 0).into();
 
-    let mut receiver = UdpStream::bind(addr).expect("receiver");
+    let mut receiver = UdpStream::<32>::bind(addr).expect("receiver");
     let rec_addr = receiver.local_addr().expect("bound port");
     dbg!(rec_addr);
 
-    let mut sender = UdpStream::bind(addr).expect("sender");
+    let mut sender = UdpStream::<32>::bind(addr).expect("sender");
     let send_addr = sender.local_addr().expect("bound port");
     dbg!(send_addr);
 


### PR DESCRIPTION
- sends M-SEARCH & listens for all responses
- includes change to make buffer size generic for UdpStream - removing fixed 65k stack allocations on each read and allowing user to decide on required buffer size