### PR TITLE
type-safely generate and parse M-SEARCH

### DIFF
--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -518,7 +518,7 @@ trait Header {
 }
 
 /// Handles constructing valid header lines.
-/// 
+///
 /// This is a separate trait from [Header] to allow for it to also be implemented on `Option<H>`
 trait HeaderExt {
     /// Generate a valid header line
@@ -540,7 +540,7 @@ impl<H: Header + Display> HeaderExt for H {
 
 impl<H: Header + HeaderExt> HeaderExt for Option<H> {
     /// Generate a valid header line
-    /// 
+    ///
     /// #### Note
     /// - This will output an empty `String` for `None`.
     ///   If this is not what you want consider using `.map(|h| h.to_header())` which
@@ -553,9 +553,9 @@ impl<H: Header + HeaderExt> HeaderExt for Option<H> {
     }
 
     /// Write a valid header line to `f` including new-line
-    /// 
+    ///
     /// #### Note
-    /// - `None` entries are handled nicely (no-op) *without* generating a blank line 
+    /// - `None` entries are handled nicely (no-op) *without* generating a blank line
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Some(header) => header.write_header(f),

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -7,9 +7,17 @@
 //!
 //! [spec]: https://openconnectivity.org/upnp-specs/UPnP-arch-DeviceArchitecture-v2.0-20200417.pdf
 
-use std::{collections::HashMap, fmt::Display, io};
+use std::{
+    collections::HashMap,
+    fmt::Display,
+    io,
+    net::{AddrParseError, SocketAddr, SocketAddrV4, SocketAddrV6},
+    str::FromStr,
+};
 
 use uuid::Uuid;
+
+use crate::MULTICAST;
 
 /// A valid & parsed ssdp message
 ///
@@ -36,10 +44,51 @@ impl Display for Message {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MSearch {
+    host: Host,
     mx: Mx,
     user_agent: Option<UserAgent>,
     friendly_name: String,
     uuid: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Host {
+    V4(SocketAddrV4),
+    /// IPv6 is currently untested & largely unimplemented
+    _V6(SocketAddrV6),
+}
+
+impl Display for Host {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Host::V4(socket_addr_v4) => write!(f, "{socket_addr_v4}"),
+            Host::_V6(socket_addr_v6) => write!(f, "{socket_addr_v6}"),
+        }
+    }
+}
+
+impl FromStr for Host {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let addr = SocketAddr::from_str(s)?;
+        Ok(addr.into())
+    }
+}
+
+impl From<SocketAddr> for Host {
+    fn from(addr: SocketAddr) -> Self {
+        match addr {
+            SocketAddr::V4(socket_addr_v4) => Self::V4(socket_addr_v4),
+            SocketAddr::V6(socket_addr_v6) => Self::_V6(socket_addr_v6),
+        }
+    }
+}
+
+impl Default for Host {
+    fn default() -> Self {
+        MULTICAST.into()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -82,13 +131,14 @@ impl From<Mx> for u8 {
 impl Display for MSearch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let Self {
+            host,
             mx,
             user_agent,
             friendly_name,
             uuid,
         } = self;
         writeln!(f, "M-SEARCH * HTTP/1.1")?;
-        writeln!(f, "HOST: 239.255.255.250:1900")?;
+        writeln!(f, "HOST: {}", host)?;
         writeln!(f, r#"MAN: "ssdp:discover""#)?;
         writeln!(f, "MX: {}", mx)?;
         writeln!(f, "ST: ssdp:all")?;
@@ -168,7 +218,9 @@ impl Message {
             product_name: product_name.to_string(),
             product_version: product_version.to_string(),
         };
+        let host = Default::default();
         Message::Search(MSearch {
+            host,
             mx,
             user_agent: Some(user_agent),
             friendly_name: friendly_name.to_string(),

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -35,13 +35,13 @@ impl Display for ParseError {
         match self {
             ParseError::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
             ParseError::InvalidST(st) => write!(f, "{} is not a valid upnp search type", st),
-            ParseError::InvalidDevice(device) => writeln!(
+            ParseError::InvalidDevice(device) => write!(
                 f,
                 "{} is not a valid upnp device specification (valid forms are `urn:domain-name:device:deviceType:ver` & `urn:schemas-upnp-org:device:deviceType:ver`)",
                 device
             ),
             ParseError::InvalidDeviceDetails(device) => {
-                writeln!(f, "{} is not a valid upnp device:ver specification", device)
+                write!(f, "{} is not a valid upnp device:ver specification", device)
             }
         }
     }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -511,12 +511,17 @@ impl Header for Uuid {
     const HEADER_KEY: &'static str = "CPUUID.UPNP.ORG";
 }
 
+/// Marker trait for Upnp header fields, with details of the relevant key
 trait Header {
+    /// Key as per spec
     const HEADER_KEY: &'static str;
 }
 
+/// Handles constructing valid header lines.
+/// 
+/// This is a separate trait from [Header] to allow for it to also be implemented on `Option<H>`
 trait HeaderExt {
-    /// Output as a valid header line
+    /// Generate a valid header line
     fn to_header(&self) -> String;
 
     /// Write a valid header line to `f` including new-line
@@ -524,18 +529,22 @@ trait HeaderExt {
 }
 
 impl<H: Header + Display> HeaderExt for H {
-    /// Output as a valid header line
     fn to_header(&self) -> String {
         format!("{}: {}", Self::HEADER_KEY, self)
     }
 
-    /// Write a valid header line to `f` including new-line
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.to_header())
     }
 }
 
 impl<H: Header + HeaderExt> HeaderExt for Option<H> {
+    /// Generate a valid header line
+    /// 
+    /// #### Note
+    /// - This will output an empty `String` for `None`.
+    ///   If this is not what you want consider using `.map(|h| h.to_header())` which
+    ///   will give you an `Option<String>` instead.
     fn to_header(&self) -> String {
         match self {
             Some(header) => header.to_header(),
@@ -543,6 +552,10 @@ impl<H: Header + HeaderExt> HeaderExt for Option<H> {
         }
     }
 
+    /// Write a valid header line to `f` including new-line
+    /// 
+    /// #### Note
+    /// - `None` entries are handled nicely (no-op) *without* generating a blank line 
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Some(header) => header.write_header(f),

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -413,4 +413,29 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003
         let msg_text = msg.to_string();
         assert_eq!(msg_text, expected);
     }
+
+    #[test]
+    fn search_no_user_agent() {
+        let expected = r#"M-SEARCH * HTTP/1.1
+HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 5
+ST: ssdp:all
+CPFN.UPNP.ORG: splurt SSDP repeater
+CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003
+
+"#;
+        let mx = 5.try_into().expect("valid mx");
+        let friendly_name = "splurt SSDP repeater";
+        let uuid = uuid!("2fac1234-31f8-11b4-a222-08002b34c003");
+        let msg = MSearch {
+            host: Default::default(),
+            mx,
+            user_agent: None,
+            friendly_name: FriendlyName(friendly_name.to_string()),
+            uuid: Some(uuid),
+        };
+        let msg_text = msg.to_string();
+        assert_eq!(msg_text, expected);
+    }
 }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -118,11 +118,19 @@ impl Header for Host {
     const HEADER_KEY: &'static str = "HOST";
 }
 
-trait Header
-where
-    Self: Display,
-{
+trait Header {
     const HEADER_KEY: &'static str;
+}
+
+trait HeaderExt {
+    /// Output as a valid header line
+    fn to_header(&self) -> String;
+
+    /// Write a valid header line to `f` including new-line
+    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+}
+
+impl<H: Header + Display> HeaderExt for H {
     /// Output as a valid header line
     fn to_header(&self) -> String {
         format!("{}: {}", Self::HEADER_KEY, self)
@@ -131,6 +139,22 @@ where
     /// Write a valid header line to `f` including new-line
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.to_header())
+    }
+}
+
+impl<H: Header + HeaderExt> HeaderExt for Option<H> {
+    fn to_header(&self) -> String {
+        match self {
+            Some(header) => header.to_header(),
+            None => String::new(),
+        }
+    }
+
+    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Some(header) => header.write_header(f),
+            None => Ok(()),
+        }
     }
 }
 
@@ -189,13 +213,9 @@ impl Display for MSearch {
         writeln!(f, r#"MAN: "ssdp:discover""#)?;
         mx.write_header(f)?;
         writeln!(f, "ST: ssdp:all")?;
-        if let Some(user_agent) = user_agent {
-            user_agent.write_header(f)?;
-        }
+        user_agent.write_header(f)?;
         friendly_name.write_header(f)?;
-        if let Some(uuid) = uuid {
-            uuid.write_header(f)?;
-        }
+        uuid.write_header(f)?;
         // Must end with blank line as per spec:
         //   "Note: No body is present in requests with method M-SEARCH, but note that the
         //          message shall have a blank line following the last header field."

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -21,26 +21,26 @@ use uuid::Uuid;
 use crate::MULTICAST;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Error {
+pub enum ParseError {
     InvalidMethod(String),
     InvalidST(String),
     InvalidDevice(String),
     InvalidDeviceDetails(String),
 }
 
-impl error::Error for Error {}
+impl error::Error for ParseError {}
 
-impl Display for Error {
+impl Display for ParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
-            Error::InvalidST(st) => write!(f, "{} is not a valid upnp search type", st),
-            Error::InvalidDevice(device) => writeln!(
+            ParseError::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
+            ParseError::InvalidST(st) => write!(f, "{} is not a valid upnp search type", st),
+            ParseError::InvalidDevice(device) => writeln!(
                 f,
                 "{} is not a valid upnp device specification (valid forms are `urn:domain-name:device:deviceType:ver` & `urn:schemas-upnp-org:device:deviceType:ver`)",
                 device
             ),
-            Error::InvalidDeviceDetails(device) => {
+            ParseError::InvalidDeviceDetails(device) => {
                 writeln!(f, "{} is not a valid upnp device:ver specification", device)
             }
         }
@@ -65,14 +65,14 @@ impl Display for Method {
 }
 
 impl FromStr for Method {
-    type Err = Error;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "M-SEARCH * HTTP/1.1" => Ok(Self::MSearch),
             "NOTIFY * HTTP/1.1" => Ok(Self::Notify),
             "HTTP/1.1 200 OK" => Ok(Self::Response),
-            _ => Err(Error::InvalidMethod(s.to_string())),
+            _ => Err(ParseError::InvalidMethod(s.to_string())),
         }
     }
 }
@@ -218,10 +218,10 @@ impl Display for DeviceDetails {
 }
 
 impl FromStr for DeviceDetails {
-    type Err = Error;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let err = || Error::InvalidDevice(s.to_string());
+        let err = || ParseError::InvalidDevice(s.to_string());
         let mut parts = s.split(":");
         match parts.next() {
             Some("urn") => (),
@@ -278,12 +278,12 @@ impl Display for Device {
 }
 
 impl FromStr for Device {
-    type Err = Error;
+    type Err = ParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (device_type, ver) = s
             .split_once(":")
-            .ok_or(Error::InvalidDeviceDetails(s.to_string()))?;
+            .ok_or(ParseError::InvalidDeviceDetails(s.to_string()))?;
         Ok(Self::Other {
             device_type: device_type.to_string(),
             ver: ver.to_string(),

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -35,6 +35,7 @@ impl Display for Error {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Method {
     MSearch,
     Notify,
@@ -138,6 +139,7 @@ impl Display for Message {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Man {
     Discover,
 }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -190,12 +190,15 @@ impl Display for MSearch {
         mx.write_header(f)?;
         writeln!(f, "ST: ssdp:all")?;
         if let Some(user_agent) = user_agent {
-            writeln!(f, "{}", user_agent.to_header())?;
+            user_agent.write_header(f)?;
         }
-        writeln!(f, "CPFN.UPNP.ORG: {}", friendly_name)?;
+        friendly_name.write_header(f)?;
         if let Some(uuid) = uuid {
             uuid.write_header(f)?;
         }
+        // Must end with blank line as per spec:
+        //   "Note: No body is present in requests with method M-SEARCH, but note that the
+        //          message shall have a blank line following the last header field."
         writeln!(f)
     }
 }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -25,6 +25,7 @@ pub enum Error {
     InvalidMethod(String),
     InvalidST(String),
     InvalidDevice(String),
+    InvalidDeviceDetails(String),
 }
 
 impl error::Error for Error {}
@@ -34,7 +35,12 @@ impl Display for Error {
         match self {
             Error::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
             Error::InvalidST(st) => write!(f, "{} is not a valid upnp search type", st),
-            Error::InvalidDevice(device) => {
+            Error::InvalidDevice(device) => writeln!(
+                f,
+                "{} is not a valid upnp device specification (valid forms are `urn:domain-name:device:deviceType:ver` & `urn:schemas-upnp-org:device:deviceType:ver`)",
+                device
+            ),
+            Error::InvalidDeviceDetails(device) => {
                 writeln!(f, "{} is not a valid upnp device:ver specification", device)
             }
         }
@@ -211,6 +217,27 @@ impl Display for DeviceDetails {
     }
 }
 
+impl FromStr for DeviceDetails {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let err = || Error::InvalidDevice(s.to_string());
+        let mut parts = s.split(":");
+        match parts.next() {
+            Some("urn") => (),
+            _ => return Err(err()),
+        };
+        let Ok(vendor) = parts.next().ok_or_else(err)?.parse::<Vendor>();
+        match parts.next() {
+            Some("device") => (),
+            _ => return Err(err()),
+        };
+        let device: String = parts.collect();
+        let device: Device = device.parse()?;
+        Ok(Self { vendor, device })
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Vendor {
     Standard,
@@ -256,7 +283,7 @@ impl FromStr for Device {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let (device_type, ver) = s
             .split_once(":")
-            .ok_or(Error::InvalidDevice(s.to_string()))?;
+            .ok_or(Error::InvalidDeviceDetails(s.to_string()))?;
         Ok(Self::Other {
             device_type: device_type.to_string(),
             ver: ver.to_string(),

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -30,228 +30,6 @@ pub enum Message {
     Search(MSearch),
 }
 
-/// Formats Message as per OCF specification (2020)
-impl Display for Message {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Message::Alive(_notification) => todo!("display alive messages"),
-            Message::Search(msearch) => {
-                write!(f, "{msearch}")
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct MSearch {
-    host: Host,
-    mx: Mx,
-    user_agent: Option<UserAgent>,
-    friendly_name: FriendlyName,
-    uuid: Option<Uuid>,
-}
-
-impl Header for Uuid {
-    const HEADER_KEY: &'static str = "CPUUID.UPNP.ORG";
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct FriendlyName(String);
-
-impl Header for FriendlyName {
-    const HEADER_KEY: &'static str = "CPFN.UPNP.ORG";
-}
-
-impl Display for FriendlyName {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl From<&str> for FriendlyName {
-    fn from(s: &str) -> Self {
-        Self(s.to_string())
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-pub enum Host {
-    V4(SocketAddrV4),
-    /// IPv6 is currently untested & largely unimplemented
-    _V6(SocketAddrV6),
-}
-
-impl Display for Host {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Host::V4(socket_addr_v4) => write!(f, "{socket_addr_v4}"),
-            Host::_V6(socket_addr_v6) => write!(f, "{socket_addr_v6}"),
-        }
-    }
-}
-
-impl FromStr for Host {
-    type Err = AddrParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let addr = SocketAddr::from_str(s)?;
-        Ok(addr.into())
-    }
-}
-
-impl From<SocketAddr> for Host {
-    fn from(addr: SocketAddr) -> Self {
-        match addr {
-            SocketAddr::V4(socket_addr_v4) => Self::V4(socket_addr_v4),
-            SocketAddr::V6(socket_addr_v6) => Self::_V6(socket_addr_v6),
-        }
-    }
-}
-
-impl Default for Host {
-    fn default() -> Self {
-        MULTICAST.into()
-    }
-}
-
-impl Header for Host {
-    const HEADER_KEY: &'static str = "HOST";
-}
-
-trait Header {
-    const HEADER_KEY: &'static str;
-}
-
-trait HeaderExt {
-    /// Output as a valid header line
-    fn to_header(&self) -> String;
-
-    /// Write a valid header line to `f` including new-line
-    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
-}
-
-impl<H: Header + Display> HeaderExt for H {
-    /// Output as a valid header line
-    fn to_header(&self) -> String {
-        format!("{}: {}", Self::HEADER_KEY, self)
-    }
-
-    /// Write a valid header line to `f` including new-line
-    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{}", self.to_header())
-    }
-}
-
-impl<H: Header + HeaderExt> HeaderExt for Option<H> {
-    fn to_header(&self) -> String {
-        match self {
-            Some(header) => header.to_header(),
-            None => String::new(),
-        }
-    }
-
-    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Some(header) => header.write_header(f),
-            None => Ok(()),
-        }
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-/// A valid MX value (0..=5) (see UPnP spec para 1.3.2)
-///
-/// - Construct via `TryFrom<u8>`
-/// - Desconstruct via `Into<u8>`
-/// - Invalid values will result in an `io::ErrorKind::InvalidInput`.
-pub struct Mx(u8);
-
-impl Display for Mx {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl TryFrom<u8> for Mx {
-    type Error = io::Error;
-
-    fn try_from(mx: u8) -> Result<Self, Self::Error> {
-        match mx {
-            0..=5 => Ok(Self(mx)),
-            _ => Err(io::Error::from(io::ErrorKind::InvalidInput)),
-        }
-    }
-}
-
-impl From<Mx> for u8 {
-    fn from(mx: Mx) -> Self {
-        mx.0
-    }
-}
-
-impl Header for Mx {
-    const HEADER_KEY: &'static str = "MX";
-}
-
-/// Entire valid M-SEARCH message including initial method line,
-/// as per OCF specification (2020) section 1.3.2
-///
-/// #### Note:
-/// I've rarely actually seen a well-formed spec-conform M-SEARCH flying around my network
-/// but there's nothing wrong with actually being fully valid!
-impl Display for MSearch {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            host,
-            mx,
-            user_agent,
-            friendly_name,
-            uuid,
-        } = self;
-        writeln!(f, "M-SEARCH * HTTP/1.1")?;
-        host.write_header(f)?;
-        writeln!(f, r#"MAN: "ssdp:discover""#)?;
-        mx.write_header(f)?;
-        writeln!(f, "ST: ssdp:all")?;
-        user_agent.write_header(f)?;
-        friendly_name.write_header(f)?;
-        uuid.write_header(f)?;
-        // Must end with blank line as per spec:
-        //   "Note: No body is present in requests with method M-SEARCH, but note that the
-        //          message shall have a blank line following the last header field."
-        writeln!(f)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-struct UserAgent {
-    os: String,
-    os_version: String,
-    product_name: String,
-    product_version: String,
-}
-
-/// Formatted as per OCF specification (2020) section 1.3.2 for the `USER-AGENT` *value*,
-/// does NOT include the header key
-impl Display for UserAgent {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let Self {
-            os,
-            os_version,
-            product_name,
-            product_version,
-        } = self;
-        write!(
-            f,
-            "{os}/{os_version} UPnP/2.0 {product_name}/{product_version}"
-        )
-    }
-}
-
-impl Header for UserAgent {
-    const HEADER_KEY: &'static str = "USER-AGENT";
-}
-
 impl Message {
     /// Parse an ssdp message from given text
     pub fn parse(contents: &str) -> Option<Message> {
@@ -303,6 +81,227 @@ impl Message {
     }
 }
 
+/// Formats Message as per OCF specification (2020)
+impl Display for Message {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Message::Alive(_notification) => todo!("display alive messages"),
+            Message::Search(msearch) => {
+                write!(f, "{msearch}")
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MSearch {
+    host: Host,
+    mx: Mx,
+    user_agent: Option<UserAgent>,
+    friendly_name: FriendlyName,
+    uuid: Option<Uuid>,
+}
+
+/// Entire valid M-SEARCH message including initial method line,
+/// as per OCF specification (2020) section 1.3.2
+///
+/// #### Note:
+/// I've rarely actually seen a well-formed spec-conform M-SEARCH flying around my network
+/// but there's nothing wrong with actually being fully valid!
+impl Display for MSearch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            host,
+            mx,
+            user_agent,
+            friendly_name,
+            uuid,
+        } = self;
+        writeln!(f, "M-SEARCH * HTTP/1.1")?;
+        host.write_header(f)?;
+        writeln!(f, r#"MAN: "ssdp:discover""#)?;
+        mx.write_header(f)?;
+        writeln!(f, "ST: ssdp:all")?;
+        user_agent.write_header(f)?;
+        friendly_name.write_header(f)?;
+        uuid.write_header(f)?;
+        // Must end with blank line as per spec:
+        //   "Note: No body is present in requests with method M-SEARCH, but note that the
+        //          message shall have a blank line following the last header field."
+        writeln!(f)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Host {
+    V4(SocketAddrV4),
+    /// IPv6 is currently untested & largely unimplemented
+    _V6(SocketAddrV6),
+}
+
+impl Header for Host {
+    const HEADER_KEY: &'static str = "HOST";
+}
+
+impl Display for Host {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Host::V4(socket_addr_v4) => write!(f, "{socket_addr_v4}"),
+            Host::_V6(socket_addr_v6) => write!(f, "{socket_addr_v6}"),
+        }
+    }
+}
+
+impl From<SocketAddr> for Host {
+    fn from(addr: SocketAddr) -> Self {
+        match addr {
+            SocketAddr::V4(socket_addr_v4) => Self::V4(socket_addr_v4),
+            SocketAddr::V6(socket_addr_v6) => Self::_V6(socket_addr_v6),
+        }
+    }
+}
+
+impl FromStr for Host {
+    type Err = AddrParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let addr = SocketAddr::from_str(s)?;
+        Ok(addr.into())
+    }
+}
+
+impl Default for Host {
+    fn default() -> Self {
+        MULTICAST.into()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+/// A valid MX value (0..=5) (see UPnP spec para 1.3.2)
+///
+/// - Construct via `TryFrom<u8>`
+/// - Desconstruct via `Into<u8>`
+/// - Invalid values will result in an `io::ErrorKind::InvalidInput`.
+pub struct Mx(u8);
+
+impl Header for Mx {
+    const HEADER_KEY: &'static str = "MX";
+}
+
+impl Display for Mx {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl TryFrom<u8> for Mx {
+    type Error = io::Error;
+
+    fn try_from(mx: u8) -> Result<Self, Self::Error> {
+        match mx {
+            0..=5 => Ok(Self(mx)),
+            _ => Err(io::Error::from(io::ErrorKind::InvalidInput)),
+        }
+    }
+}
+
+impl From<Mx> for u8 {
+    fn from(mx: Mx) -> Self {
+        mx.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct UserAgent {
+    os: String,
+    os_version: String,
+    product_name: String,
+    product_version: String,
+}
+
+impl Header for UserAgent {
+    const HEADER_KEY: &'static str = "USER-AGENT";
+}
+
+/// Formatted as per OCF specification (2020) section 1.3.2 for the `USER-AGENT` *value*,
+/// does NOT include the header key
+impl Display for UserAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let Self {
+            os,
+            os_version,
+            product_name,
+            product_version,
+        } = self;
+        write!(
+            f,
+            "{os}/{os_version} UPnP/2.0 {product_name}/{product_version}"
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FriendlyName(String);
+
+impl Header for FriendlyName {
+    const HEADER_KEY: &'static str = "CPFN.UPNP.ORG";
+}
+
+impl Display for FriendlyName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for FriendlyName {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
+}
+
+impl Header for Uuid {
+    const HEADER_KEY: &'static str = "CPUUID.UPNP.ORG";
+}
+
+trait Header {
+    const HEADER_KEY: &'static str;
+}
+
+trait HeaderExt {
+    /// Output as a valid header line
+    fn to_header(&self) -> String;
+
+    /// Write a valid header line to `f` including new-line
+    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+}
+
+impl<H: Header + Display> HeaderExt for H {
+    /// Output as a valid header line
+    fn to_header(&self) -> String {
+        format!("{}: {}", Self::HEADER_KEY, self)
+    }
+
+    /// Write a valid header line to `f` including new-line
+    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self.to_header())
+    }
+}
+
+impl<H: Header + HeaderExt> HeaderExt for Option<H> {
+    fn to_header(&self) -> String {
+        match self {
+            Some(header) => header.to_header(),
+            None => String::new(),
+        }
+    }
+
+    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Some(header) => header.write_header(f),
+            None => Ok(()),
+        }
+    }
+}
 #[derive(Debug, Clone, PartialEq)]
 pub struct Notification {
     location: Option<String>,

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -209,9 +209,7 @@ impl Display for DeviceDetails {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Vendor {
-    #[expect(unused)]
     Standard,
-    #[expect(unused)]
     Custom(String),
 }
 
@@ -224,7 +222,16 @@ impl Display for Vendor {
     }
 }
 
-//TODO impl FromStr for Vendor
+ impl FromStr for Vendor {
+    type Err = !;
+ 
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "schemas-upnp-org" => Ok(Self::Standard),
+            _ => Ok(Self::Custom(s.to_string())),
+        }
+    }
+ }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Device {

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -91,6 +91,21 @@ impl Default for Host {
     }
 }
 
+impl Header for Host {
+    const HEADER_KEY: &'static str = "HOST";
+}
+
+trait Header
+where
+    Self: Display,
+{
+    const HEADER_KEY: &'static str;
+    /// Output as a valid header line
+    fn to_header(&self) -> String {
+        format!("{}: {}", Self::HEADER_KEY, self)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// A valid MX value (0..=5) (see UPnP spec para 1.3.2)
 ///
@@ -138,7 +153,7 @@ impl Display for MSearch {
             uuid,
         } = self;
         writeln!(f, "M-SEARCH * HTTP/1.1")?;
-        writeln!(f, "HOST: {}", host)?;
+        writeln!(f, "{}", host.to_header())?;
         writeln!(f, r#"MAN: "ssdp:discover""#)?;
         writeln!(f, "MX: {}", mx)?;
         writeln!(f, "ST: ssdp:all")?;

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -9,6 +9,7 @@
 
 use std::{
     collections::HashMap,
+    error,
     fmt::Display,
     io,
     net::{AddrParseError, SocketAddr, SocketAddrV4, SocketAddrV6},
@@ -18,6 +19,50 @@ use std::{
 use uuid::Uuid;
 
 use crate::MULTICAST;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Error {
+    InvalidMethod(String),
+}
+
+impl error::Error for Error {}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
+        }
+    }
+}
+
+pub enum Method {
+    MSearch,
+    Notify,
+    Response,
+}
+
+impl Display for Method {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Method::MSearch => write!(f, "M-SEARCH * HTTP/1.1"),
+            Method::Notify => write!(f, "NOTIFY * HTTP/1.1"),
+            Method::Response => write!(f, "HTTP/1.1 200 OK"),
+        }
+    }
+}
+
+impl FromStr for Method {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "M-SEARCH * HTTP/1.1" => Ok(Self::MSearch),
+            "NOTIFY * HTTP/1.1" => Ok(Self::Notify),
+            "HTTP/1.1 200 OK" => Ok(Self::Response),
+            _ => Err(Error::InvalidMethod(s.to_string())),
+        }
+    }
+}
 
 /// A valid & parsed ssdp message
 ///
@@ -117,7 +162,7 @@ impl Display for MSearch {
             friendly_name,
             uuid,
         } = self;
-        writeln!(f, "M-SEARCH * HTTP/1.1")?;
+        writeln!(f, "{}", Method::MSearch)?;
         host.write_header(f)?;
         writeln!(f, r#"MAN: "ssdp:discover""#)?;
         mx.write_header(f)?;

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -24,6 +24,7 @@ use crate::MULTICAST;
 pub enum Error {
     InvalidMethod(String),
     InvalidST(String),
+    InvalidDevice(String),
 }
 
 impl error::Error for Error {}
@@ -33,6 +34,9 @@ impl Display for Error {
         match self {
             Error::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
             Error::InvalidST(st) => write!(f, "{} is not a valid upnp search type", st),
+            Error::InvalidDevice(device) => {
+                writeln!(f, "{} is not a valid upnp device:ver specification", device)
+            }
         }
     }
 }
@@ -222,20 +226,19 @@ impl Display for Vendor {
     }
 }
 
- impl FromStr for Vendor {
+impl FromStr for Vendor {
     type Err = !;
- 
+
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "schemas-upnp-org" => Ok(Self::Standard),
             _ => Ok(Self::Custom(s.to_string())),
         }
     }
- }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Device {
-    #[expect(unused)]
     Other { device_type: String, ver: String },
 }
 
@@ -244,6 +247,20 @@ impl Display for Device {
         match self {
             Device::Other { device_type, ver } => write!(f, "{}:{}", device_type, ver),
         }
+    }
+}
+
+impl FromStr for Device {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (device_type, ver) = s
+            .split_once(":")
+            .ok_or(Error::InvalidDevice(s.to_string()))?;
+        Ok(Self::Other {
+            device_type: device_type.to_string(),
+            ver: ver.to_string(),
+        })
     }
 }
 

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -166,8 +166,10 @@ enum ST {
     /// `ssdp:all`: Search for all devices and services.
     All,
     /// `upnp:rootdevice`: Search for root devices only.
+    #[expect(unused)]
     Root,
     /// uuid:device-UUID: Search for a particular device.
+    #[expect(unused)]
     Uuid(Uuid),
     /// `urn:schemas-upnp-org:device:deviceType:ver`:
     ///     Search for any device of this type where `deviceType` and `ver` are
@@ -178,6 +180,7 @@ enum ST {
     ///     specifies the highest supported version of the device type. Period characters in
     ///     the Vendor Domain Name shall be replaced with hyphens in accordance with RFC 2141.
     /// TODO: #36 DeviceTypes
+    #[expect(unused)]
     Device(DeviceDetails),
     /// `urn:schemas-upnp-org:service:serviceType:ver`:
     ///     Search for any service of this type where serviceType and ver are
@@ -188,6 +191,7 @@ enum ST {
     ///     specifies the highest supported version of the service type. Period characters in
     ///     the Vendor Domain Name shall be replaced with hyphens in accordance with RFC 2141.
     /// TODO: #37 ServiceTypes
+    #[expect(unused)]
     Service(ServiceDetails),
 }
 
@@ -205,7 +209,9 @@ impl Display for DeviceDetails {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Vendor {
+    #[expect(unused)]
     Standard,
+    #[expect(unused)]
     Custom(String),
 }
 
@@ -222,6 +228,7 @@ impl Display for Vendor {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Device {
+    #[expect(unused)]
     Other { device_type: String, ver: String },
 }
 
@@ -247,6 +254,7 @@ impl Display for ServiceDetails {
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum Service {
+    #[expect(unused)]
     Other { service_type: String, ver: String },
 }
 
@@ -274,15 +282,13 @@ impl Display for ST {
     }
 }
 
-impl FromStr for ST {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            _ => todo!("from str ST"),
-        }
-    }
-}
+//TODO: impl FromStr for ST {
+//     type Err = Error;
+//
+//     fn from_str(s: &str) -> Result<Self, Self::Err> {
+//         todo!("from str ST")
+//     }
+// }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MSearch {

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -138,6 +138,24 @@ impl Display for Message {
     }
 }
 
+pub enum Man {
+    Discover,
+}
+
+impl Display for Man {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let str = match self {
+            Man::Discover => "ssdp:discover",
+        };
+        // MAN values are enclosed in double-quotes
+        write!(f, r#""{}""#, str)
+    }
+}
+
+impl Header for Man {
+    const HEADER_KEY: &'static str = "MAN";
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MSearch {
     host: Host,
@@ -164,7 +182,7 @@ impl Display for MSearch {
         } = self;
         writeln!(f, "{}", Method::MSearch)?;
         host.write_header(f)?;
-        writeln!(f, r#"MAN: "ssdp:discover""#)?;
+        Man::Discover.write_header(f)?;
         mx.write_header(f)?;
         writeln!(f, "ST: ssdp:all")?;
         user_agent.write_header(f)?;

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -23,6 +23,7 @@ use crate::MULTICAST;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Error {
     InvalidMethod(String),
+    InvalidST(String),
 }
 
 impl error::Error for Error {}
@@ -31,6 +32,7 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
+            Error::InvalidST(st) => write!(f, "{} is not a valid upnp search type", st),
         }
     }
 }
@@ -159,6 +161,130 @@ impl Header for Man {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// Search Target
+enum ST {
+    /// `ssdp:all`: Search for all devices and services.
+    All,
+    /// `upnp:rootdevice`: Search for root devices only.
+    Root,
+    /// uuid:device-UUID: Search for a particular device.
+    Uuid(Uuid),
+    /// `urn:schemas-upnp-org:device:deviceType:ver`:
+    ///     Search for any device of this type where `deviceType` and `ver` are
+    ///     defined by the UPnP Forum working committee.
+    /// `urn:domain-name:device:deviceType:ver`:
+    ///     Search for any device of this typewhere domain-name (a Vendor Domain Name),
+    ///     deviceType and ver are defined by the UPnP vendor and ver specifies the highest
+    ///     specifies the highest supported version of the device type. Period characters in
+    ///     the Vendor Domain Name shall be replaced with hyphens in accordance with RFC 2141.
+    /// TODO: #36 DeviceTypes
+    Device(DeviceDetails),
+    /// `urn:schemas-upnp-org:service:serviceType:ver`:
+    ///     Search for any service of this type where serviceType and ver are
+    ///     defined by the UPnP Forum working committee.
+    /// `urn:domain-name:service:serviceType:ver`:
+    ///     Search for any service of this type. Where domain-name (a Vendor Domain Name),
+    ///     serviceType and ver are defined by the UPnP vendor and ver specifies the highest
+    ///     specifies the highest supported version of the service type. Period characters in
+    ///     the Vendor Domain Name shall be replaced with hyphens in accordance with RFC 2141.
+    /// TODO: #37 ServiceTypes
+    Service(ServiceDetails),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct DeviceDetails {
+    vendor: Vendor,
+    device: Device,
+}
+
+impl Display for DeviceDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:device:{}", self.vendor, self.device)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Vendor {
+    Standard,
+    Custom(String),
+}
+
+impl Display for Vendor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Vendor::Standard => write!(f, "schemas-upnp-org"),
+            Vendor::Custom(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+//TODO impl FromStr for Vendor
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Device {
+    Other { device_type: String, ver: String },
+}
+
+impl Display for Device {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Device::Other { device_type, ver } => write!(f, "{}:{}", device_type, ver),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ServiceDetails {
+    vendor: Vendor,
+    service: Service,
+}
+
+impl Display for ServiceDetails {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:service:{}", self.vendor, self.service)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum Service {
+    Other { service_type: String, ver: String },
+}
+
+impl Display for Service {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Service::Other { service_type, ver } => write!(f, "{}:{}", service_type, ver),
+        }
+    }
+}
+
+impl Header for ST {
+    const HEADER_KEY: &'static str = "ST";
+}
+
+impl Display for ST {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ST::All => write!(f, "ssdp:all"),
+            ST::Root => write!(f, "upnp:rootdevice"),
+            ST::Uuid(uuid) => write!(f, "uuid:device-{}", uuid),
+            ST::Device(device_details) => write!(f, "urn:{device_details}"),
+            ST::Service(service_details) => write!(f, "urn:{service_details}"),
+        }
+    }
+}
+
+impl FromStr for ST {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            _ => todo!("from str ST"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MSearch {
     host: Host,
     mx: Mx,
@@ -186,7 +312,7 @@ impl Display for MSearch {
         host.write_header(f)?;
         Man::Discover.write_header(f)?;
         mx.write_header(f)?;
-        writeln!(f, "ST: ssdp:all")?;
+        ST::All.write_header(f)?;
         user_agent.write_header(f)?;
         friendly_name.write_header(f)?;
         uuid.write_header(f)?;

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -137,6 +137,10 @@ impl From<Mx> for u8 {
     }
 }
 
+impl Header for Mx {
+    const HEADER_KEY: &'static str = "MX";
+}
+
 /// Entire valid M-SEARCH message including initial method line,
 /// as per OCF specification (2020) section 1.3.2
 ///
@@ -155,7 +159,7 @@ impl Display for MSearch {
         writeln!(f, "M-SEARCH * HTTP/1.1")?;
         writeln!(f, "{}", host.to_header())?;
         writeln!(f, r#"MAN: "ssdp:discover""#)?;
-        writeln!(f, "MX: {}", mx)?;
+        writeln!(f, "{}", mx.to_header())?;
         writeln!(f, "ST: ssdp:all")?;
         if let Some(user_agent) = user_agent {
             writeln!(f, "USER-AGENT: {}", user_agent)?;

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -51,6 +51,10 @@ pub struct MSearch {
     uuid: Option<Uuid>,
 }
 
+impl Header for Uuid {
+    const HEADER_KEY: &'static str = "CPUUID.UPNP.ORG";
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct FriendlyName(String);
 
@@ -190,7 +194,7 @@ impl Display for MSearch {
         }
         writeln!(f, "CPFN.UPNP.ORG: {}", friendly_name)?;
         if let Some(uuid) = uuid {
-            writeln!(f, "CPUUID.UPNP.ORG: {}", uuid)?;
+            uuid.write_header(f)?;
         }
         writeln!(f)
     }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -47,8 +47,27 @@ pub struct MSearch {
     host: Host,
     mx: Mx,
     user_agent: Option<UserAgent>,
-    friendly_name: String,
+    friendly_name: FriendlyName,
     uuid: Option<Uuid>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FriendlyName(String);
+
+impl Header for FriendlyName {
+    const HEADER_KEY: &'static str = "CPFN.UPNP.ORG";
+}
+
+impl Display for FriendlyName {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<&str> for FriendlyName {
+    fn from(s: &str) -> Self {
+        Self(s.to_string())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -251,7 +270,7 @@ impl Message {
             host,
             mx,
             user_agent: Some(user_agent),
-            friendly_name: friendly_name.to_string(),
+            friendly_name: friendly_name.into(),
             uuid: Some(uuid),
         })
     }

--- a/ssdp-rs/src/message.rs
+++ b/ssdp-rs/src/message.rs
@@ -104,6 +104,11 @@ where
     fn to_header(&self) -> String {
         format!("{}: {}", Self::HEADER_KEY, self)
     }
+
+    /// Write a valid header line to `f` including new-line
+    fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "{}", self.to_header())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -157,12 +162,12 @@ impl Display for MSearch {
             uuid,
         } = self;
         writeln!(f, "M-SEARCH * HTTP/1.1")?;
-        writeln!(f, "{}", host.to_header())?;
+        host.write_header(f)?;
         writeln!(f, r#"MAN: "ssdp:discover""#)?;
-        writeln!(f, "{}", mx.to_header())?;
+        mx.write_header(f)?;
         writeln!(f, "ST: ssdp:all")?;
         if let Some(user_agent) = user_agent {
-            writeln!(f, "USER-AGENT: {}", user_agent)?;
+            writeln!(f, "{}", user_agent.to_header())?;
         }
         writeln!(f, "CPFN.UPNP.ORG: {}", friendly_name)?;
         if let Some(uuid) = uuid {
@@ -195,6 +200,10 @@ impl Display for UserAgent {
             "{os}/{os_version} UPnP/2.0 {product_name}/{product_version}"
         )
     }
+}
+
+impl Header for UserAgent {
+    const HEADER_KEY: &'static str = "USER-AGENT";
 }
 
 impl Message {


### PR DESCRIPTION
- adds Header & HeaderExt traits
- adds Display & FromStr impls
- adds dedicated types for Header fields as per spec