### PR TITLE
streamline parsing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -242,3 +242,9 @@ impl<T: _T> From<futures_util::task::SpawnError> for Exit<T> {
         Self::Error(e.to_string())
     }
 }
+
+impl<T: _T> From<ssdp_rs::Error> for Exit<T> {
+    fn from(e: ssdp_rs::Error) -> Self {
+        Self::Error(e.to_string())
+    }
+}

--- a/ssdp-rs/Cargo.toml
+++ b/ssdp-rs/Cargo.toml
@@ -15,7 +15,12 @@ publish = false
 
 [dependencies]
 chrono = "0.4.44"
-derive_more = { version = "2.1.1", features = ["display", "from_str"] }
+derive_more = { version = "2.1.1", features = [
+    "display",
+    "from",
+    "from_str",
+    "into",
+] }
 futures = "0.3.32"
 futures-timer = "3.0.3"
 futures-udp = { workspace = true }

--- a/ssdp-rs/src/error.rs
+++ b/ssdp-rs/src/error.rs
@@ -1,0 +1,33 @@
+//! Top level error handling.
+
+use std::io;
+
+use derive_more::Display;
+
+use crate::message::{ErrorKind, ParseError};
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+#[derive(Debug, Display)]
+pub enum Error {
+    ParseError(ParseError),
+    IOError(io::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Self {
+        Self::IOError(err)
+    }
+}
+
+impl From<ParseError> for Error {
+    fn from(err: ParseError) -> Self {
+        Self::ParseError(err)
+    }
+}
+
+impl From<ErrorKind> for Error {
+    fn from(err: ErrorKind) -> Self {
+        Self::ParseError(err.into())
+    }
+}

--- a/ssdp-rs/src/error.rs
+++ b/ssdp-rs/src/error.rs
@@ -31,3 +31,12 @@ impl From<ErrorKind> for Error {
         Self::ParseError(err.into())
     }
 }
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::ParseError(parse_error) => Some(parse_error),
+            Error::IOError(error) => Some(error),
+        }
+    }
+}

--- a/ssdp-rs/src/lib.rs
+++ b/ssdp-rs/src/lib.rs
@@ -12,10 +12,12 @@
 
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
+pub mod error;
 pub mod listener;
 pub mod message;
 pub mod search;
 
+pub use error::{Error, Result};
 pub use listener::Listener;
 pub use search::Searcher;
 

--- a/ssdp-rs/src/message/error.rs
+++ b/ssdp-rs/src/message/error.rs
@@ -18,6 +18,7 @@ pub enum ErrorKind {
     InvalidIPAddress(net::AddrParseError),
     InvalidLocation(String),
     InvalidMethod(String),
+    InvalidMx(String),
     InvalidNT(String),
     InvalidNTS(String),
     InvalidPort(String),
@@ -108,6 +109,10 @@ impl Display for ErrorKind {
             ErrorKind::InvalidIPAddress(err) => write!(f, "{err}"),
             ErrorKind::InvalidLocation(location) => write!(f, "{location} is not a valid url"),
             ErrorKind::InvalidMethod(method) => write!(f, "{} is not a valid upnp method", method),
+            ErrorKind::InvalidMx(mx) => write!(
+                f,
+                "{mx} is not a valid MX value. Only integers 0..=5 are valid."
+            ),
             ErrorKind::InvalidNT(nt) => write!(f, "{} is not a valid NT in this context", nt),
             ErrorKind::InvalidNTS(nts) => write!(f, "{} is not a valid NTS in this context", nts),
             ErrorKind::InvalidPort(port) => write!(f, "{port} is not a valid IP port"),

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -551,6 +551,18 @@ impl TryFrom<Url> for SecureLocation {
     }
 }
 
+impl PartialEq<Url> for SecureLocation {
+    fn eq(&self, other: &Url) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<SecureLocation> for Url {
+    fn eq(&self, other: &SecureLocation) -> bool {
+        *self == other.0
+    }
+}
+
 pub type Server = ProductTokens<"SERVER">;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -526,47 +526,55 @@ impl<const _FLD: &'static str> Display for ProductTokens<_FLD> {
         )
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SecureLocation(Option<Url>);
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+pub struct SecureLocation(Url);
 
 impl Header for SecureLocation {
     const HEADER_KEY: &'static str = "SECURELOCATION.UPNP.ORG";
 }
 
-impl TryFrom<Option<&str>> for SecureLocation {
-    type Error = ErrorKind;
+impl FromStr for SecureLocation {
+    type Err = ErrorKind;
 
-    fn try_from(url: Option<&str>) -> Result<Self, Self::Error> {
-        match url {
-            Some(url) => {
-                Ok(Self(Some(url.parse().map_err(|_| {
-                    ErrorKind::InvalidSecureLocation(url.to_string())
-                })?)))
-            }
-            None => Ok(Self(None)),
-        }
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        todo!("fromstr for sec loc")
     }
 }
 
-impl SecureLocation {
-    pub fn as_option(&self) -> &Option<Url> {
-        &self.0
-    }
+// impl TryFrom<Option<&str>> for SecureLocation {
+//     type Error = ErrorKind;
 
-    pub fn validate(&self) -> Result<&Self, ErrorKind> {
-        match self.as_option() {
-            None => Ok(self),
-            Some(secure_location)
-                if secure_location.scheme() == "https" && secure_location.port().is_some() =>
-            {
-                Ok(self)
-            }
-            Some(insecure_location) => Err(ErrorKind::InvalidSecureLocation(
-                insecure_location.to_string(),
-            )),
-        }
-    }
-}
+//     fn try_from(url: Option<&str>) -> Result<Self, Self::Error> {
+//         match url {
+//             Some(url) => {
+//                 Ok(Self(Some(url.parse().map_err(|_| {
+//                     ErrorKind::InvalidSecureLocation(url.to_string())
+//                 })?)))
+//             }
+//             None => Ok(Self(None)),
+//         }
+//     }
+// }
+
+// impl SecureLocation {
+//     pub fn as_option(&self) -> &Option<Url> {
+//         &self.0
+//     }
+
+//     pub fn validate(&self) -> Result<&Self, ErrorKind> {
+//         match self.as_option() {
+//             None => Ok(self),
+//             Some(secure_location)
+//                 if secure_location.scheme() == "https" && secure_location.port().is_some() =>
+//             {
+//                 Ok(self)
+//             }
+//             Some(insecure_location) => Err(ErrorKind::InvalidSecureLocation(
+//                 insecure_location.to_string(),
+//             )),
+//         }
+//     }
+// }
 
 pub type Server = ProductTokens<"SERVER">;
 

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -139,6 +139,10 @@ impl<H: Header + HeaderExt> HeaderExt for Option<H> {
     }
 }
 
+// TODO
+// pub trait Optional with blanket impl for UpnpPort & SecureLocation based on TryFrom option &str
+// provides validated get from header analog UpnpV2Ext
+
 /// For types which are required in UPnP V2 but not V1 and can be represented as an `Option<T>`
 pub trait UpnpV2<T> {
     const ERR: ErrorKind;
@@ -654,6 +658,7 @@ impl TryFrom<Option<&str>> for UpnpPort {
             .into())
     }
 }
+
 /// `None` maps to `Default`
 impl From<Option<u16>> for UpnpPort {
     fn from(port: Option<u16>) -> Self {

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -182,30 +182,25 @@ where
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct BootId(Option<u32>);
+pub struct BootId(u32);
 
 impl Header for BootId {
     const HEADER_KEY: &'static str = "BOOTID.UPNP.ORG";
 }
 
-impl TryFrom<Option<&str>> for BootId {
-    type Error = ErrorKind;
+impl FromStr for BootId {
+    type Err = ErrorKind;
 
-    fn try_from(id: Option<&str>) -> Result<Self, Self::Error> {
-        match id {
-            Some(id) => Ok(Self(Some(
-                id.parse()
-                    .map_err(|_| ErrorKind::InvalidBootId(id.to_string()))?,
-            ))),
-            None => Ok(Self(None)),
-        }
+    fn from_str(id: &str) -> Result<Self, Self::Err> {
+        let err = |_| ErrorKind::InvalidBootId(id.to_string());
+        let id = id.parse::<u32>().map_err(err)?.into();
+        Ok(id)
     }
 }
 
-impl UpnpV2<u32> for BootId {
-    const ERR: ErrorKind = ErrorKind::MissingBootId;
-    fn as_option(&self) -> &Option<u32> {
-        &self.0
+impl From<u32> for BootId {
+    fn from(value: u32) -> Self {
+        Self(value)
     }
 }
 

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -149,6 +149,37 @@ where
 // pub trait Optional with blanket impl for UpnpPort & SecureLocation based on TryFrom option &str
 // provides validated get from header analog UpnpV2Ext
 
+pub trait UpnpV2
+where
+    Self: Sized,
+{
+    const ERR: ErrorKind;
+}
+
+pub trait UpnpV2Ext
+where
+    Self: Sized,
+{
+    fn get_validated(header: &UpnpHeader<'_>, upnp_version: Version) -> Result<Self, ParseError>;
+}
+
+impl<H, E> UpnpV2Ext for Option<H>
+where
+    H: UpnpV2 + Header + HeaderExt + FromStr<Err = E>,
+    ParseError: From<E>,
+{
+    fn get_validated(header: &UpnpHeader<'_>, upnp_version: Version) -> Result<Self, ParseError> {
+        let this = Option::<H>::get_from(header)?;
+        match upnp_version.major {
+            ..=1 => Ok(this),
+            2.. => match this {
+                Some(_) => Ok(this),
+                None => Err(H::ERR)?,
+            },
+        }
+    }
+}
+
 /// For types which are required in UPnP V2 but not V1 and can be represented as an `Option<T>`
 pub trait UpnpV2_<T> {
     const ERR: ErrorKind;

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -155,6 +155,18 @@ pub trait UpnpV2<T> {
     }
 }
 
+pub trait UpnpV2Ext<T, E>:
+    UpnpV2<T> + for<'a> TryFrom<Option<&'a str>, Error = E> + Header + Sized
+where
+    ErrorKind: From<E>,
+{
+    fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind> {
+        let this: Self = header.get(Self::HEADER_KEY).try_into()?;
+        this.validate(upnp_version)?;
+        Ok(this)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BootId(Option<u32>);
 

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -423,8 +423,11 @@ impl Header for Mx {
 impl FromStr for Mx {
     type Err = ErrorKind;
 
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        todo!("from str mx")
+    fn from_str(mx: &str) -> Result<Self, Self::Err> {
+        let err = |_| ErrorKind::InvalidMx(mx.to_string());
+        let mx = mx.parse::<u8>().map_err(err)?;
+        let mx = mx.try_into().expect("valid mx");
+        Ok(mx)
     }
 }
 
@@ -729,7 +732,6 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     #[test]
-    #[should_panic(expected = "not yet implemented: from str mx")]
     fn get_option() {
         let msg = r#"HOST: 239.255.255.250:1900
 MAN: "ssdp:discover"

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -481,6 +481,7 @@ impl<const _FLD: &'static str> FromStr for ProductTokens<_FLD> {
         let err = || ErrorKind::InvalidUserAgent(user_agent.to_string());
         let (os_token, rest) = user_agent.split_once("UPnP/").ok_or_else(err)?;
         // TODO: How to handle removing "," while allowing "OS Foo/6.3 (wibblish)"
+        // https://datatracker.ietf.org/doc/html/rfc9110#name-server for formal grammar
         let os_token = os_token.trim_matches(|c: char| !c.is_alphanumeric());
         let (os, os_version) = match os_token.split_once("/") {
             Some((os, os_version)) => (os.to_string(), os_version.to_string()),

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -390,14 +390,23 @@ impl FromStr for MaxAge {
     type Err = ErrorKind;
 
     fn from_str(max_age: &str) -> Result<Self, Self::Err> {
-        let (_, secs) = max_age
-            .split_once("max-age=")
-            .ok_or_else(|| ErrorKind::InvalidDuration(max_age.to_string()))?;
-        let duration = Duration::from_secs(
-            secs.parse()
-                .map_err(|_| ErrorKind::InvalidDuration(max_age.to_string()))?,
-        );
+        let err = || ErrorKind::InvalidDuration(max_age.to_string());
+        let (_, secs) = max_age.split_once("max-age").ok_or_else(err)?;
+        let secs = secs.trim_start_matches(|c: char| !c.is_ascii_alphanumeric());
+        let duration = Duration::from_secs(secs.parse().map_err(|_| err())?);
         Ok(Self(duration))
+    }
+}
+
+impl PartialEq<Duration> for MaxAge {
+    fn eq(&self, other: &Duration) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<MaxAge> for Duration {
+    fn eq(&self, other: &MaxAge) -> bool {
+        *self == other.0
     }
 }
 

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -146,24 +146,20 @@ where
 }
 
 /// For types which are required in UPnP V2 but not V1 and can be represented as an `Option<T>`
-pub trait UpnpV2
-where
-    Self: Sized,
-{
+pub trait UpnpV2 {
     const ERR: ErrorKind;
 }
 
-pub trait UpnpV2Ext
-where
-    Self: Sized,
-{
-    fn get_validated(header: &UpnpHeader<'_>, upnp_version: Version) -> Result<Self, ParseError>;
+pub trait UpnpV2Ext {
+    fn get_validated(header: &UpnpHeader<'_>, upnp_version: Version) -> Result<Self, ParseError>
+    where
+        Self: Sized;
 }
 
-impl<H, E> UpnpV2Ext for Option<H>
+impl<H> UpnpV2Ext for Option<H>
 where
-    H: UpnpV2 + Header + HeaderExt + FromStr<Err = E>,
-    ParseError: From<E>,
+    H: UpnpV2,
+    Option<H>: HeaderExt,
 {
     fn get_validated(header: &UpnpHeader<'_>, upnp_version: Version) -> Result<Self, ParseError> {
         let this = Option::<H>::get_from(header)?;
@@ -177,7 +173,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 pub struct BootId(u32);
 
 impl Header for BootId {
@@ -204,8 +200,8 @@ impl From<u32> for BootId {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ConfigId(Option<u32>);
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+pub struct ConfigId(u32);
 
 impl Header for ConfigId {
     const HEADER_KEY: &'static str = "CONFIGID.UPNP.ORG";
@@ -215,18 +211,19 @@ impl UpnpV2 for ConfigId {
     const ERR: ErrorKind = ErrorKind::MissingConfigId;
 }
 
-impl TryFrom<Option<&str>> for ConfigId {
-    type Error = ErrorKind;
+impl FromStr for ConfigId {
+    type Err = ErrorKind;
 
-    fn try_from(id: Option<&str>) -> Result<Self, Self::Error> {
-        match id {
-            Some(id) => {
-                Ok(Self(Some(id.parse().map_err(|_| {
-                    ErrorKind::InvalidConfigId(id.to_string())
-                })?)))
-            }
-            None => Ok(Self(None)),
-        }
+    fn from_str(id: &str) -> Result<Self, Self::Err> {
+        let err = |_| ErrorKind::InvalidConfigId(id.to_string());
+        let id = id.parse::<u32>().map_err(err)?.into();
+        Ok(id)
+    }
+}
+
+impl From<u32> for ConfigId {
+    fn from(value: u32) -> Self {
+        Self(value)
     }
 }
 

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -155,9 +155,13 @@ pub trait UpnpV2<T> {
     }
 }
 
-pub trait UpnpV2Ext<T, E>:
-    UpnpV2<T> + for<'a> TryFrom<Option<&'a str>, Error = E> + Header + Sized
+pub trait UpnpV2Ext<T>: UpnpV2<T> + Header + Sized {
+    fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind>;
+}
+
+impl<U, T, E> UpnpV2Ext<T> for U
 where
+    U: UpnpV2<T> + for<'a> TryFrom<Option<&'a str>, Error = E> + Header + Sized,
     ErrorKind: From<E>,
 {
     fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind> {

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -731,7 +731,7 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     #[test]
-    fn get_option() {
+    fn get_option_some() {
         let msg = r#"HOST: 239.255.255.250:1900
 MAN: "ssdp:discover"
 MX: 5
@@ -742,5 +742,18 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
         let header: UpnpHeader = msg.lines().collect();
         let mx = Option::<Mx>::get_from(&header).expect("optional MX");
         assert_matches!(mx, Some(mx) if mx == Mx(5));
+    }
+
+    #[test]
+    fn get_option_none() {
+        let msg = r#"HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+ST: ssdp:all
+USER-AGENT: linux/6.6.87 UPnP/2.0 splurt/0.0.1
+CPFN.UPNP.ORG: splurt SSDP repeater
+CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
+        let header: UpnpHeader = msg.lines().collect();
+        let mx = Option::<Mx>::get_from(&header).expect("optional MX");
+        assert_matches!(mx, None);
     }
 }

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -145,10 +145,7 @@ where
     }
 }
 
-// TODO
-// pub trait Optional with blanket impl for UpnpPort & SecureLocation based on TryFrom option &str
-// provides validated get from header analog UpnpV2Ext
-
+/// For types which are required in UPnP V2 but not V1 and can be represented as an `Option<T>`
 pub trait UpnpV2
 where
     Self: Sized,
@@ -180,43 +177,15 @@ where
     }
 }
 
-/// For types which are required in UPnP V2 but not V1 and can be represented as an `Option<T>`
-pub trait UpnpV2_<T> {
-    const ERR: ErrorKind;
-
-    fn as_option(&self) -> &Option<T>;
-    fn validate(&self, upnp_version: Version) -> Result<&Self, ErrorKind> {
-        match upnp_version.major {
-            ..=1 => Ok(self),
-            2.. => match self.as_option() {
-                Some(_) => Ok(self),
-                None => Err(Self::ERR),
-            },
-        }
-    }
-}
-
-pub trait UpnpV2Ext_<T>: UpnpV2_<T> + Header + Sized {
-    fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind>;
-}
-
-impl<U, T, E> UpnpV2Ext_<T> for U
-where
-    U: UpnpV2_<T> + for<'a> TryFrom<Option<&'a str>, Error = E> + Header + Sized,
-    ErrorKind: From<E>,
-{
-    fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind> {
-        let this: Self = header.get(Self::HEADER_KEY).try_into()?;
-        this.validate(upnp_version)?;
-        Ok(this)
-    }
-}
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BootId(u32);
 
 impl Header for BootId {
     const HEADER_KEY: &'static str = "BOOTID.UPNP.ORG";
+}
+
+impl UpnpV2 for BootId {
+    const ERR: ErrorKind = ErrorKind::MissingBootId;
 }
 
 impl FromStr for BootId {
@@ -242,6 +211,10 @@ impl Header for ConfigId {
     const HEADER_KEY: &'static str = "CONFIGID.UPNP.ORG";
 }
 
+impl UpnpV2 for ConfigId {
+    const ERR: ErrorKind = ErrorKind::MissingConfigId;
+}
+
 impl TryFrom<Option<&str>> for ConfigId {
     type Error = ErrorKind;
 
@@ -254,13 +227,6 @@ impl TryFrom<Option<&str>> for ConfigId {
             }
             None => Ok(Self(None)),
         }
-    }
-}
-
-impl UpnpV2_<u32> for ConfigId {
-    const ERR: ErrorKind = ErrorKind::MissingConfigId;
-    fn as_option(&self) -> &Option<u32> {
-        &self.0
     }
 }
 

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -83,7 +83,7 @@ pub trait HeaderExt {
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
 
     /// Attempt to get and parse this from a UpnpHeader
-    fn get_from(header: UpnpHeader<'_>) -> Result<Self, ParseError>
+    fn get_from(header: &UpnpHeader<'_>) -> Result<Self, ParseError>
     where
         Self: Sized;
 }
@@ -101,7 +101,7 @@ where
         writeln!(f, "{}", self.to_header())
     }
 
-    fn get_from(header: UpnpHeader<'_>) -> Result<Self, ParseError> {
+    fn get_from(header: &UpnpHeader<'_>) -> Result<Self, ParseError> {
         Ok(header.try_get(Self::HEADER_KEY)?.parse()?)
     }
 }
@@ -131,7 +131,7 @@ impl<H: Header + HeaderExt> HeaderExt for Option<H> {
         }
     }
 
-    fn get_from(_header: UpnpHeader<'_>) -> Result<Self, ParseError>
+    fn get_from(_header: &UpnpHeader<'_>) -> Result<Self, ParseError>
     where
         Self: Sized,
     {

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -81,15 +81,28 @@ pub trait HeaderExt {
 
     /// Write a valid header line to `f` including new-line
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+
+    /// Attempt to get and parse this from a UpnpHeader
+    fn get_from(header: UpnpHeader<'_>) -> Result<Self, ParseError>
+    where
+        Self: Sized;
 }
 
-impl<H: Header + Display> HeaderExt for H {
+impl<H, E> HeaderExt for H
+where
+    H: Header + Display + FromStr<Err = E>,
+    ParseError: From<E>,
+{
     fn to_header(&self) -> String {
         format!("{}: {}", Self::HEADER_KEY, self)
     }
 
     fn write_header(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         writeln!(f, "{}", self.to_header())
+    }
+
+    fn get_from(header: UpnpHeader<'_>) -> Result<Self, ParseError> {
+        Ok(header.try_get(Self::HEADER_KEY)?.parse()?)
     }
 }
 
@@ -116,6 +129,13 @@ impl<H: Header + HeaderExt> HeaderExt for Option<H> {
             Some(header) => header.write_header(f),
             None => Ok(()),
         }
+    }
+
+    fn get_from(_header: UpnpHeader<'_>) -> Result<Self, ParseError>
+    where
+        Self: Sized,
+    {
+        todo!("get_from for option")
     }
 }
 
@@ -192,12 +212,40 @@ impl UpnpV2<u32> for ConfigId {
     }
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+pub struct ControlPointUuid(Uuid);
+
+impl Header for ControlPointUuid {
+    const HEADER_KEY: &'static str = "CPUUID.UPNP.ORG";
+}
+
+impl FromStr for ControlPointUuid {
+    type Err = ErrorKind;
+
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        todo!("fromstr controlpoint uuid")
+    }
+}
+
+impl From<Uuid> for ControlPointUuid {
+    fn from(uuid: Uuid) -> Self {
+        Self(uuid)
+    }
+}
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 // TODO make private inner when impl FromStr
 pub struct FriendlyName(pub String);
 
 impl Header for FriendlyName {
     const HEADER_KEY: &'static str = "CPFN.UPNP.ORG";
+}
+
+impl FromStr for FriendlyName {
+    type Err = ErrorKind;
+
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        todo!("fromstr for friendly name")
+    }
 }
 
 // TODO Replace with FromStr
@@ -286,6 +334,14 @@ impl Header for Man {
     const HEADER_KEY: &'static str = "MAN";
 }
 
+impl FromStr for Man {
+    type Err = ErrorKind;
+
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        todo!("man from str")
+    }
+}
+
 impl Display for Man {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let str = match self {
@@ -329,6 +385,14 @@ pub struct Mx(u8);
 
 impl Header for Mx {
     const HEADER_KEY: &'static str = "MX";
+}
+
+impl FromStr for Mx {
+    type Err = ErrorKind;
+
+    fn from_str(_s: &str) -> Result<Self, Self::Err> {
+        todo!("from str mx")
+    }
 }
 
 impl TryFrom<u8> for Mx {
@@ -591,10 +655,6 @@ impl From<UpnpPort> for u16 {
 }
 
 pub type UserAgent = ProductTokens<"USER-AGENT">;
-
-impl Header for Uuid {
-    const HEADER_KEY: &'static str = "CPUUID.UPNP.ORG";
-}
 
 /// Upnp version
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -783,4 +783,17 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
         );
         assert!(err.source().is_none());
     }
+
+    #[test]
+    fn secure_location_no_port() {
+        let msg = r#"SECURELOCATION.UPNP.ORG: http://192.168.0.15/xml/device_description.xml
+"#;
+        let header: UpnpHeader = msg.lines().collect();
+        let err =
+            Option::<SecureLocation>::get_from(&header).expect_err("has invalid SecureLocation");
+        assert_matches!(err.kind, ErrorKind::InvalidSecureLocation(ref loc)
+            if loc == "http://192.168.0.15/xml/device_description.xml"
+        );
+        assert!(err.source().is_none());
+    }
 }

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -258,7 +258,6 @@ impl Display for FriendlyName {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
-// TODO: A way to get the addr back out
 pub struct Host(SocketAddr);
 
 impl Header for Host {
@@ -339,7 +338,6 @@ impl Header for MaxAge {
     const HEADER_KEY: &'static str = "CACHE-CONTROL";
 }
 
-// TODO: Update to TryFrom pattern
 impl FromStr for MaxAge {
     // TODO: #50 Move all FromStr impls to use Err = ParseError
     type Err = ErrorKind;

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -780,4 +780,27 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
         assert_matches!(err.kind, ErrorKind::InvalidMx(ref mx) if mx =="6");
         assert!(err.source().is_none());
     }
+
+    #[test]
+    #[should_panic(expected = "fromstr for sec loc")]
+    fn secure_location() {
+        let msg = r#"SECURELOCATION.UPNP.ORG: https://192.168.0.15:8001/xml/device_description.xml
+"#;
+        let header: UpnpHeader = msg.lines().collect();
+        let secure_location =
+            Option::<SecureLocation>::get_from(&header).expect("has SecureLocation");
+        assert_matches!(secure_location, Some(_));
+    }
+
+    #[test]
+    #[should_panic(expected = "fromstr for sec loc")]
+    fn secure_location_invalid_scheme() {
+        let msg = r#"SECURELOCATION.UPNP.ORG: http://192.168.0.15:8001/xml/device_description.xml
+"#;
+        let header: UpnpHeader = msg.lines().collect();
+        let err =
+            Option::<SecureLocation>::get_from(&header).expect_err("has invalid SecureLocation");
+        assert_matches!(err.kind, ErrorKind::InvalidSecureLocation(ref loc) if loc == "http://192.168.0.15:8001/xml/device_description.xml");
+        assert!(err.source().is_none());
+    }
 }

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -13,7 +13,6 @@
 use std::{
     collections::HashMap,
     fmt::Display,
-    io,
     net::{AddrParseError, SocketAddr},
     str::FromStr,
     time::Duration,
@@ -432,12 +431,12 @@ impl FromStr for Mx {
 }
 
 impl TryFrom<u8> for Mx {
-    type Error = io::Error;
+    type Error = ErrorKind;
 
     fn try_from(mx: u8) -> Result<Self, Self::Error> {
         match mx {
             0..=5 => Ok(Self(mx)),
-            _ => Err(io::Error::from(io::ErrorKind::InvalidInput)),
+            _ => Err(ErrorKind::InvalidMx(mx.to_string())),
         }
     }
 }

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -547,45 +547,14 @@ impl FromStr for SecureLocation {
 impl TryFrom<Url> for SecureLocation {
     type Error = ErrorKind;
 
-    fn try_from(value: Url) -> Result<Self, Self::Error> {
-        todo!("try from url for sec loc")
+    fn try_from(url: Url) -> Result<Self, Self::Error> {
+        if url.scheme() == "https" && url.port().is_some() && !url.cannot_be_a_base() {
+            Ok(Self(url))
+        } else {
+            Err(ErrorKind::InvalidSecureLocation(url.to_string()))
+        }
     }
 }
-
-// impl TryFrom<Option<&str>> for SecureLocation {
-//     type Error = ErrorKind;
-
-//     fn try_from(url: Option<&str>) -> Result<Self, Self::Error> {
-//         match url {
-//             Some(url) => {
-//                 Ok(Self(Some(url.parse().map_err(|_| {
-//                     ErrorKind::InvalidSecureLocation(url.to_string())
-//                 })?)))
-//             }
-//             None => Ok(Self(None)),
-//         }
-//     }
-// }
-
-// impl SecureLocation {
-//     pub fn as_option(&self) -> &Option<Url> {
-//         &self.0
-//     }
-
-//     pub fn validate(&self) -> Result<&Self, ErrorKind> {
-//         match self.as_option() {
-//             None => Ok(self),
-//             Some(secure_location)
-//                 if secure_location.scheme() == "https" && secure_location.port().is_some() =>
-//             {
-//                 Ok(self)
-//             }
-//             Some(insecure_location) => Err(ErrorKind::InvalidSecureLocation(
-//                 insecure_location.to_string(),
-//             )),
-//         }
-//     }
-// }
 
 pub type Server = ProductTokens<"SERVER">;
 
@@ -793,7 +762,6 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
     }
 
     #[test]
-    #[should_panic(expected = "try from url for sec loc")]
     fn secure_location() {
         let msg = r#"SECURELOCATION.UPNP.ORG: https://192.168.0.15:8001/xml/device_description.xml
 "#;
@@ -804,7 +772,6 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
     }
 
     #[test]
-    #[should_panic(expected = "try from url for sec loc")]
     fn secure_location_invalid_scheme() {
         let msg = r#"SECURELOCATION.UPNP.ORG: http://192.168.0.15:8001/xml/device_description.xml
 "#;

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -536,8 +536,19 @@ impl Header for SecureLocation {
 impl FromStr for SecureLocation {
     type Err = ErrorKind;
 
-    fn from_str(_s: &str) -> Result<Self, Self::Err> {
-        todo!("fromstr for sec loc")
+    fn from_str(url: &str) -> Result<Self, Self::Err> {
+        let err = |_| ErrorKind::InvalidSecureLocation(url.to_string());
+        let url = url.parse::<Url>().map_err(err)?;
+        let secure_location = url.try_into()?;
+        Ok(secure_location)
+    }
+}
+
+impl TryFrom<Url> for SecureLocation {
+    type Error = ErrorKind;
+
+    fn try_from(value: Url) -> Result<Self, Self::Error> {
+        todo!("try from url for sec loc")
     }
 }
 
@@ -782,7 +793,7 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
     }
 
     #[test]
-    #[should_panic(expected = "fromstr for sec loc")]
+    #[should_panic(expected = "try from url for sec loc")]
     fn secure_location() {
         let msg = r#"SECURELOCATION.UPNP.ORG: https://192.168.0.15:8001/xml/device_description.xml
 "#;
@@ -793,7 +804,7 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
     }
 
     #[test]
-    #[should_panic(expected = "fromstr for sec loc")]
+    #[should_panic(expected = "try from url for sec loc")]
     fn secure_location_invalid_scheme() {
         let msg = r#"SECURELOCATION.UPNP.ORG: http://192.168.0.15:8001/xml/device_description.xml
 "#;

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use derive_more::Display;
+use derive_more::{Display, From, Into};
 use url::Url;
 use uuid::Uuid;
 
@@ -173,7 +173,7 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
 pub struct BootId(u32);
 
 impl Header for BootId {
@@ -194,12 +194,6 @@ impl FromStr for BootId {
     }
 }
 
-impl From<u32> for BootId {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
 impl PartialEq<u32> for BootId {
     fn eq(&self, other: &u32) -> bool {
         self.0 == *other
@@ -212,7 +206,7 @@ impl PartialEq<BootId> for u32 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
 pub struct ConfigId(u32);
 
 impl Header for ConfigId {
@@ -233,13 +227,7 @@ impl FromStr for ConfigId {
     }
 }
 
-impl From<u32> for ConfigId {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
 pub struct ControlPointUuid(Uuid);
 
 impl Header for ControlPointUuid {
@@ -254,12 +242,7 @@ impl FromStr for ControlPointUuid {
     }
 }
 
-impl From<Uuid> for ControlPointUuid {
-    fn from(uuid: Uuid) -> Self {
-        Self(uuid)
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, From, Into)]
 // TODO make private inner when impl FromStr
 pub struct FriendlyName(pub String);
 
@@ -288,7 +271,7 @@ impl Display for FriendlyName {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
 // TODO: A way to get the addr back out
 pub struct Host(SocketAddr);
 
@@ -318,12 +301,6 @@ impl FromStr for Host {
     }
 }
 
-impl From<SocketAddr> for Host {
-    fn from(addr: SocketAddr) -> Self {
-        Self(addr)
-    }
-}
-
 impl Host {
     /// Return [ErrorKind::InvalidHost] if not [MULTICAST]
     pub fn check_multicast(&self) -> Result<(), ErrorKind> {
@@ -334,7 +311,7 @@ impl Host {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
 pub struct Location(Url);
 
 impl Header for Location {
@@ -379,13 +356,14 @@ impl Display for Man {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Into)]
 pub struct MaxAge(pub(crate) Duration);
 
 impl Header for MaxAge {
     const HEADER_KEY: &'static str = "CACHE-CONTROL";
 }
 
+// TODO: Update to TryFrom pattern
 impl FromStr for MaxAge {
     // TODO: #50 Move all FromStr impls to use Err = ParseError
     type Err = ErrorKind;
@@ -417,7 +395,7 @@ impl Display for MaxAge {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Into)]
 /// A valid MX value (0..=5) (see UPnP spec para 1.3.2)
 ///
 /// - Construct via `TryFrom<u8>`
@@ -448,12 +426,6 @@ impl TryFrom<u8> for Mx {
             0..=5 => Ok(Self(mx)),
             _ => Err(ErrorKind::InvalidMx(mx.to_string())),
         }
-    }
-}
-
-impl From<Mx> for u8 {
-    fn from(mx: Mx) -> Self {
-        mx.0
     }
 }
 
@@ -523,7 +495,7 @@ impl<const _FLD: &'static str> Display for ProductTokens<_FLD> {
         )
     }
 }
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, Into)]
 pub struct SecureLocation(Url);
 
 impl Header for SecureLocation {

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -150,7 +150,7 @@ where
 // provides validated get from header analog UpnpV2Ext
 
 /// For types which are required in UPnP V2 but not V1 and can be represented as an `Option<T>`
-pub trait UpnpV2<T> {
+pub trait UpnpV2_<T> {
     const ERR: ErrorKind;
 
     fn as_option(&self) -> &Option<T>;
@@ -165,13 +165,13 @@ pub trait UpnpV2<T> {
     }
 }
 
-pub trait UpnpV2Ext<T>: UpnpV2<T> + Header + Sized {
+pub trait UpnpV2Ext_<T>: UpnpV2_<T> + Header + Sized {
     fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind>;
 }
 
-impl<U, T, E> UpnpV2Ext<T> for U
+impl<U, T, E> UpnpV2Ext_<T> for U
 where
-    U: UpnpV2<T> + for<'a> TryFrom<Option<&'a str>, Error = E> + Header + Sized,
+    U: UpnpV2_<T> + for<'a> TryFrom<Option<&'a str>, Error = E> + Header + Sized,
     ErrorKind: From<E>,
 {
     fn get_validated(header: &UpnpHeader, upnp_version: Version) -> Result<Self, ErrorKind> {
@@ -226,7 +226,7 @@ impl TryFrom<Option<&str>> for ConfigId {
     }
 }
 
-impl UpnpV2<u32> for ConfigId {
+impl UpnpV2_<u32> for ConfigId {
     const ERR: ErrorKind = ErrorKind::MissingConfigId;
     fn as_option(&self) -> &Option<u32> {
         &self.0

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -106,7 +106,11 @@ where
     }
 }
 
-impl<H: Header + HeaderExt> HeaderExt for Option<H> {
+impl<H, E> HeaderExt for Option<H>
+where
+    H: Header + HeaderExt + FromStr<Err = E>,
+    ParseError: From<E>,
+{
     /// Generate a valid header line
     ///
     /// #### Note
@@ -131,11 +135,14 @@ impl<H: Header + HeaderExt> HeaderExt for Option<H> {
         }
     }
 
-    fn get_from(_header: &UpnpHeader<'_>) -> Result<Self, ParseError>
+    fn get_from(header: &UpnpHeader<'_>) -> Result<Self, ParseError>
     where
         Self: Sized,
     {
-        todo!("get_from for option")
+        Ok(header
+            .get(H::HEADER_KEY)
+            .map(|val| val.parse::<H>())
+            .transpose()?)
     }
 }
 
@@ -722,7 +729,7 @@ mod tests {
     use std::assert_matches::assert_matches;
 
     #[test]
-    #[should_panic(expected = "not yet implemented: get_from for option")]
+    #[should_panic(expected = "not yet implemented: from str mx")]
     fn get_option() {
         let msg = r#"HOST: 239.255.255.250:1900
 MAN: "ssdp:discover"

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -710,3 +710,29 @@ impl Display for Version {
         write!(f, "{}.{}", self.major, self.minor)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(assert_matches_in_root)]
+    use std::assert_matches;
+
+    #[cfg(assert_matches_in_module)]
+    use std::assert_matches::assert_matches;
+
+    #[test]
+    #[should_panic(expected = "not yet implemented: get_from for option")]
+    fn get_option() {
+        let msg = r#"HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 5
+ST: ssdp:all
+USER-AGENT: linux/6.6.87 UPnP/2.0 splurt/0.0.1
+CPFN.UPNP.ORG: splurt SSDP repeater
+CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
+        let header: UpnpHeader = msg.lines().collect();
+        let mx = Option::<Mx>::get_from(&header).expect("optional MX");
+        assert_matches!(mx, Some(mx) if mx == Mx(5));
+    }
+}

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -425,7 +425,7 @@ impl FromStr for Mx {
     fn from_str(mx: &str) -> Result<Self, Self::Err> {
         let err = |_| ErrorKind::InvalidMx(mx.to_string());
         let mx = mx.parse::<u8>().map_err(err)?;
-        let mx = mx.try_into().expect("valid mx");
+        let mx = mx.try_into()?;
         Ok(mx)
     }
 }
@@ -729,6 +729,7 @@ mod tests {
 
     #[cfg(assert_matches_in_module)]
     use std::assert_matches::assert_matches;
+    use std::error::Error;
 
     #[test]
     fn get_option_some() {
@@ -755,5 +756,20 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
         let header: UpnpHeader = msg.lines().collect();
         let mx = Option::<Mx>::get_from(&header).expect("optional MX");
         assert_matches!(mx, None);
+    }
+
+    #[test]
+    fn get_option_invalid() {
+        let msg = r#"HOST: 239.255.255.250:1900
+MAN: "ssdp:discover"
+MX: 6
+ST: ssdp:all
+USER-AGENT: linux/6.6.87 UPnP/2.0 splurt/0.0.1
+CPFN.UPNP.ORG: splurt SSDP repeater
+CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
+        let header: UpnpHeader = msg.lines().collect();
+        let err = Option::<Mx>::get_from(&header).expect_err("invalid MX");
+        assert_matches!(err.kind, ErrorKind::InvalidMx(ref mx) if mx =="6");
+        assert!(err.source().is_none());
     }
 }

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -800,7 +800,9 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003"#;
         let header: UpnpHeader = msg.lines().collect();
         let err =
             Option::<SecureLocation>::get_from(&header).expect_err("has invalid SecureLocation");
-        assert_matches!(err.kind, ErrorKind::InvalidSecureLocation(ref loc) if loc == "http://192.168.0.15:8001/xml/device_description.xml");
+        assert_matches!(err.kind, ErrorKind::InvalidSecureLocation(ref loc)
+            if loc == "http://192.168.0.15:8001/xml/device_description.xml"
+        );
         assert!(err.source().is_none());
     }
 }

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -375,6 +375,12 @@ impl FromStr for MaxAge {
     }
 }
 
+impl Display for MaxAge {
+    fn fmt(&self, _f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        todo!("display MaxAge")
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 /// A valid MX value (0..=5) (see UPnP spec para 1.3.2)
 ///

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -479,35 +479,21 @@ impl<const _FLD: &'static str> FromStr for ProductTokens<_FLD> {
 
     fn from_str(user_agent: &str) -> Result<Self, Self::Err> {
         let err = || ErrorKind::InvalidUserAgent(user_agent.to_string());
-        // Wierd & slightly backwards splitting as product_name may contain spaces
-        let mut token_ish = user_agent.split("/");
-        let os = token_ish.next().ok_or_else(err)?.to_string();
-        // TODO: Check there was a "Upnp" in the right place
-        let (os_version, _upnp) = token_ish
-            .next()
-            .ok_or_else(err)?
-            .split_once(" ")
-            .ok_or_else(err)
-            .map(|(ver, upnp)| {
-                (
-                    ver.trim_end_matches(|c: char| !c.is_alphanumeric())
-                        .to_string(),
-                    upnp,
-                )
-            })?;
-        let (ver, prod) = token_ish
-            .next()
-            .ok_or_else(err)?
-            .split_once(" ")
-            .ok_or_else(err)?;
-        let upnp_version = ver
-            .trim_end_matches(|c: char| !c.is_alphanumeric())
-            .parse()?;
-        let product_name = prod.to_string();
-        let product_version = token_ish.next().ok_or_else(err)?.to_string();
-        if token_ish.next().is_some() {
-            return Err(err());
+        let (os_token, rest) = user_agent.split_once("UPnP/").ok_or_else(err)?;
+        // TODO: How to handle removing "," while allowing "OS Foo/6.3 (wibblish)"
+        let os_token = os_token.trim_matches(|c: char| !c.is_alphanumeric());
+        let (os, os_version) = match os_token.split_once("/") {
+            Some((os, os_version)) => (os.to_string(), os_version.to_string()),
+            None => (os_token.to_string(), "".to_string()),
         };
+        let (upnp_version, product) = rest.split_once(" ").ok_or_else(err)?;
+        let upnp_version: Version = upnp_version
+            .trim_matches(|c: char| !c.is_alphanumeric())
+            .parse()?;
+        let (product_name, product_version) = product
+            .split_once("/")
+            .ok_or_else(err)
+            .map(|(name, ver)| (name.to_string(), ver.to_string()))?;
         Ok(Self {
             os,
             os_version,

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -18,7 +18,7 @@ use std::{
     time::Duration,
 };
 
-use derive_more::{Display, From, Into};
+use derive_more::{Display, From, FromStr, Into};
 use url::Url;
 use uuid::Uuid;
 
@@ -173,7 +173,10 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into, FromStr,
+)]
+#[from_str(error(ErrorKind, |_| ErrorKind::InvalidBootId(s.to_string())))]
 pub struct BootId(u32);
 
 impl Header for BootId {
@@ -182,16 +185,6 @@ impl Header for BootId {
 
 impl UpnpV2 for BootId {
     const ERR: ErrorKind = ErrorKind::MissingBootId;
-}
-
-impl FromStr for BootId {
-    type Err = ErrorKind;
-
-    fn from_str(id: &str) -> Result<Self, Self::Err> {
-        let err = |_| ErrorKind::InvalidBootId(id.to_string());
-        let id = id.parse::<u32>().map_err(err)?.into();
-        Ok(id)
-    }
 }
 
 impl PartialEq<u32> for BootId {
@@ -206,7 +199,10 @@ impl PartialEq<BootId> for u32 {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into, FromStr,
+)]
+#[from_str(error(ErrorKind, |_| ErrorKind::InvalidConfigId(s.to_string())))]
 pub struct ConfigId(u32);
 
 impl Header for ConfigId {
@@ -215,16 +211,6 @@ impl Header for ConfigId {
 
 impl UpnpV2 for ConfigId {
     const ERR: ErrorKind = ErrorKind::MissingConfigId;
-}
-
-impl FromStr for ConfigId {
-    type Err = ErrorKind;
-
-    fn from_str(id: &str) -> Result<Self, Self::Err> {
-        let err = |_| ErrorKind::InvalidConfigId(id.to_string());
-        let id = id.parse::<u32>().map_err(err)?.into();
-        Ok(id)
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
@@ -311,22 +297,12 @@ impl Host {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From, Into, FromStr)]
+#[from_str(error(ErrorKind, |_| ErrorKind::InvalidLocation(s.to_string())))]
 pub struct Location(Url);
 
 impl Header for Location {
     const HEADER_KEY: &'static str = "LOCATION";
-}
-
-impl FromStr for Location {
-    type Err = ErrorKind;
-
-    fn from_str(url: &str) -> Result<Self, Self::Err> {
-        match url.parse() {
-            Ok(url) => Ok(Self(url)),
-            Err(_) => Err(ErrorKind::InvalidLocation(url.to_string())),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -356,7 +332,7 @@ impl Display for Man {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Into)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, From, Into)]
 pub struct MaxAge(pub(crate) Duration);
 
 impl Header for MaxAge {
@@ -395,7 +371,7 @@ impl Display for MaxAge {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Into)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Into, Display)]
 /// A valid MX value (0..=5) (see UPnP spec para 1.3.2)
 ///
 /// - Construct via `TryFrom<u8>`
@@ -429,11 +405,6 @@ impl TryFrom<u8> for Mx {
     }
 }
 
-impl Display for Mx {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ProductTokens<const FIELD_NAME: &'static str> {
     pub os: String,

--- a/ssdp-rs/src/message/header.rs
+++ b/ssdp-rs/src/message/header.rs
@@ -200,6 +200,18 @@ impl From<u32> for BootId {
     }
 }
 
+impl PartialEq<u32> for BootId {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<BootId> for u32 {
+    fn eq(&self, other: &BootId) -> bool {
+        *self == other.0
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 pub struct ConfigId(u32);
 

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -400,6 +400,6 @@ X-SONOS-HHSECURELOCATION: https://192.168.0.84:1843/xml/device_description.xml
             if secure_location == Url::from_str("https://192.168.0.84:1443/xml/device_description.xml").expect("parsed url")
         );
         assert_eq!(response.server.product_version, "85.0-64200 (ZPS29)");
-        // assert_matches!(response.boot_id, Some(id) if id == 6);
+        assert_matches!(response.boot_id, Some(id) if id == 6);
     }
 }

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -176,6 +176,7 @@ impl Display for Vendor {
 #[cfg(test)]
 mod tests {
 
+    use url::Url;
     use uuid::uuid;
 
     use crate::message::header::Version;
@@ -395,5 +396,8 @@ X-SONOS-HHSECURELOCATION: https://192.168.0.84:1843/xml/device_description.xml
             panic!("{msg} not a response")
         };
         assert_eq!(response.max_age, Duration::from_secs(1800));
+        assert_matches!(response.secure_location, Some(secure_location)
+            if secure_location == Url::from_str("https://192.168.0.84:1443/xml/device_description.xml").expect("parsed url")
+        );
     }
 }

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -399,5 +399,6 @@ X-SONOS-HHSECURELOCATION: https://192.168.0.84:1843/xml/device_description.xml
         assert_matches!(response.secure_location, Some(secure_location)
             if secure_location == Url::from_str("https://192.168.0.84:1443/xml/device_description.xml").expect("parsed url")
         );
+        assert_eq!(response.server.product_version, "85.0-64200 (ZPS29)");
     }
 }

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -114,7 +114,7 @@ impl Message {
             mx,
             user_agent: Some(user_agent),
             friendly_name: friendly_name.into(),
-            uuid: Some(uuid),
+            uuid: Some(uuid.into()),
         })
     }
 }
@@ -313,7 +313,7 @@ CPUUID.UPNP.ORG: 2fac1234-31f8-11b4-a222-08002b34c003
             mx,
             user_agent: None,
             friendly_name: FriendlyName(friendly_name.to_string()),
-            uuid: Some(uuid),
+            uuid: Some(uuid.into()),
         };
         let msg_text = msg.to_string();
         assert_eq!(msg_text, expected);

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -400,5 +400,6 @@ X-SONOS-HHSECURELOCATION: https://192.168.0.84:1843/xml/device_description.xml
             if secure_location == Url::from_str("https://192.168.0.84:1443/xml/device_description.xml").expect("parsed url")
         );
         assert_eq!(response.server.product_version, "85.0-64200 (ZPS29)");
+        assert_matches!(response.boot_id, Some(id) if id == 6);
     }
 }

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -368,4 +368,32 @@ NTS: ssdp:byebye
 USN: uuid:2f402f80-da50-11e1-9b23-ecb5fa15c4c8::urn:schemas-upnp-org:device:basic:1"#;
         let _msg: Message = byebye.parse().expect("byebye message");
     }
+
+    #[test]
+    /// Has a BootId, SecureLocation & ProductVersion suffix
+    fn parse_sonos() {
+        let sonos = r#"HTTP/1.1 200 OK
+CACHE-CONTROL: max-age = 1800
+EXT:
+LOCATION: http://192.168.0.84:1400/xml/device_description.xml
+SERVER: Linux UPnP/1.0 Sonos/85.0-64200 (ZPS29)
+ST: urn:schemas-upnp-org:service:VirtualLineIn:1
+USN: uuid:RINCON_38420B91BAF001400_MR::urn:schemas-upnp-org:service:VirtualLineIn:1
+X-RINCON-HOUSEHOLD: Sonos_J9hfdYcBvSBCyHLo5tPwpI9Cm3
+X-RINCON-BOOTSEQ: 6
+BOOTID.UPNP.ORG: 6
+X-RINCON-WIFIMODE: 1
+X-RINCON-VARIANT: 2
+HOUSEHOLD.SMARTSPEAKER.AUDIO: Sonos_J9hfdYcBvSBCyHLo5tPwpI9Cm3.9LpAqreapUbAY1tsy5BF
+LOCATION.SMARTSPEAKER.AUDIO: lc_4e8119cfb08d4c5083b6e0c75e47fe50
+SECURELOCATION.UPNP.ORG: https://192.168.0.84:1443/xml/device_description.xml
+X-SONOS-HHSECURELOCATION: https://192.168.0.84:1843/xml/device_description.xml
+
+"#;
+        let msg: Message = sonos.parse().expect("sonos valid message");
+        let Message::Response(response) = msg else {
+            panic!("{msg} not a response")
+        };
+        assert_eq!(response.max_age, Duration::from_secs(1800));
+    }
 }

--- a/ssdp-rs/src/message/mod.rs
+++ b/ssdp-rs/src/message/mod.rs
@@ -400,6 +400,6 @@ X-SONOS-HHSECURELOCATION: https://192.168.0.84:1843/xml/device_description.xml
             if secure_location == Url::from_str("https://192.168.0.84:1443/xml/device_description.xml").expect("parsed url")
         );
         assert_eq!(response.server.product_version, "85.0-64200 (ZPS29)");
-        assert_matches!(response.boot_id, Some(id) if id == 6);
+        // assert_matches!(response.boot_id, Some(id) if id == 6);
     }
 }

--- a/ssdp-rs/src/message/msearch.rs
+++ b/ssdp-rs/src/message/msearch.rs
@@ -1,8 +1,6 @@
 use std::fmt::Display;
 
-use uuid::Uuid;
-
-use crate::message::header::UserAgent;
+use crate::message::header::{ControlPointUuid, UserAgent};
 
 use super::{FriendlyName, HeaderExt, Host, Man, Method, Mx, ST};
 
@@ -12,7 +10,7 @@ pub struct MSearch {
     pub mx: Mx,
     pub user_agent: Option<UserAgent>,
     pub friendly_name: FriendlyName,
-    pub uuid: Option<Uuid>,
+    pub uuid: Option<ControlPointUuid>,
 }
 
 /// Entire valid M-SEARCH message including initial method line,

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -83,8 +83,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
     fn try_from(header: UpnpHeader<'h>) -> Result<Self, Self::Error> {
         let max_age = header.try_get(MaxAge::HEADER_KEY)?.parse()?;
         let location = Location::get_from(&header)?;
-        let nt = header.try_get(NT::HEADER_KEY)?.parse()?;
-        let server: Server = header.try_get(Server::HEADER_KEY)?.parse()?;
+        let nt = NT::get_from(&header)?;
+        let server = Server::get_from(&header)?;
         let uuid = *Usn::from_uri_and_nt(&header.try_get(Usn::HEADER_KEY)?.parse::<Uri>()?, &nt)?
             .as_uuid();
         let boot_id: BootId = header.get(BootId::HEADER_KEY).try_into()?;
@@ -137,7 +137,7 @@ impl<'h> TryFrom<UpnpHeader<'h>> for ByeBye {
     type Error = ParseError;
 
     fn try_from(header: UpnpHeader<'h>) -> Result<Self, Self::Error> {
-        let nt = header.try_get(NT::HEADER_KEY)?.parse()?;
+        let nt = NT::get_from(&header)?;
         let uuid = *Usn::from_uri_and_nt(&header.try_get(Usn::HEADER_KEY)?.parse::<Uri>()?, &nt)?
             .as_uuid();
         // TODO - document Boot & ConfigID validation must be done by something that has a

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::message::{
     DeviceDetails, Header, HeaderExt, Host, MaxAge, ServiceDetails, Target, UpnpNss, UpnpPort,
-    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext},
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext_},
     uri::UriExt,
 };
 

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -6,7 +6,7 @@ use derive_more::Display;
 use uuid::Uuid;
 
 use crate::message::{
-    DeviceDetails, Header, Host, MaxAge, ServiceDetails, Target, UpnpNss, UpnpPort,
+    DeviceDetails, Header, HeaderExt, Host, MaxAge, ServiceDetails, Target, UpnpNss, UpnpPort,
     header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2},
     uri::UriExt,
 };
@@ -82,7 +82,7 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
 
     fn try_from(header: UpnpHeader<'h>) -> Result<Self, Self::Error> {
         let max_age = header.try_get(MaxAge::HEADER_KEY)?.parse()?;
-        let location = header.try_get(Location::HEADER_KEY)?.parse()?;
+        let location = Location::get_from(&header)?;
         let nt = header.try_get(NT::HEADER_KEY)?.parse()?;
         let server: Server = header.try_get(Server::HEADER_KEY)?.parse()?;
         let uuid = *Usn::from_uri_and_nt(&header.try_get(Usn::HEADER_KEY)?.parse::<Uri>()?, &nt)?

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -74,7 +74,7 @@ pub struct Alive {
     port: UpnpPort,
     /// `SECURELOCATION.UPNP.ORG`: provides a base URL, with `https:` scheme and a specific port.
     /// Required when device protection is implemented.
-    secure_location: SecureLocation,
+    secure_location: Option<SecureLocation>,
 }
 
 impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
@@ -90,8 +90,7 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
         let boot_id = BootId::get_validated(&header, server.upnp_version)?;
         let config_id = ConfigId::get_validated(&header, server.upnp_version)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
-        let secure_location: SecureLocation = header.get(SecureLocation::HEADER_KEY).try_into()?;
-        secure_location.validate()?;
+        let secure_location = Option::<SecureLocation>::get_from(&header)?;
         Ok(Self {
             max_age,
             location,

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::message::{
     DeviceDetails, Header, HeaderExt, Host, MaxAge, ServiceDetails, Target, UpnpNss, UpnpPort,
-    header::{BootId, ConfigId, Location, SecureLocation, Server},
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext},
     uri::UriExt,
 };
 
@@ -87,8 +87,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
         let server = Server::get_from(&header)?;
         let uuid = *Usn::from_uri_and_nt(&header.try_get(Usn::HEADER_KEY)?.parse::<Uri>()?, &nt)?
             .as_uuid();
-        let boot_id = Option::<BootId>::get_from(&header)?;
-        let config_id = Option::<ConfigId>::get_from(&header)?;
+        let boot_id = Option::<BootId>::get_validated(&header, server.upnp_version)?;
+        let config_id = Option::<ConfigId>::get_validated(&header, server.upnp_version)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
         let secure_location = Option::<SecureLocation>::get_from(&header)?;
         Ok(Self {

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -81,7 +81,7 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
     type Error = ParseError;
 
     fn try_from(header: UpnpHeader<'h>) -> Result<Self, Self::Error> {
-        let max_age = header.try_get(MaxAge::HEADER_KEY)?.parse()?;
+        let max_age = MaxAge::get_from(&header)?;
         let location = Location::get_from(&header)?;
         let nt = NT::get_from(&header)?;
         let server = Server::get_from(&header)?;

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::message::{
     DeviceDetails, Header, HeaderExt, Host, MaxAge, ServiceDetails, Target, UpnpNss, UpnpPort,
-    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2},
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext},
     uri::UriExt,
 };
 
@@ -87,10 +87,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
         let server = Server::get_from(&header)?;
         let uuid = *Usn::from_uri_and_nt(&header.try_get(Usn::HEADER_KEY)?.parse::<Uri>()?, &nt)?
             .as_uuid();
-        let boot_id: BootId = header.get(BootId::HEADER_KEY).try_into()?;
-        boot_id.validate(server.upnp_version)?;
-        let config_id: ConfigId = header.get(ConfigId::HEADER_KEY).try_into()?;
-        config_id.validate(server.upnp_version)?;
+        let boot_id = BootId::get_validated(&header, server.upnp_version)?;
+        let config_id = ConfigId::get_validated(&header, server.upnp_version)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
         let secure_location: SecureLocation = header.get(SecureLocation::HEADER_KEY).try_into()?;
         secure_location.validate()?;

--- a/ssdp-rs/src/message/notify.rs
+++ b/ssdp-rs/src/message/notify.rs
@@ -7,7 +7,7 @@ use uuid::Uuid;
 
 use crate::message::{
     DeviceDetails, Header, HeaderExt, Host, MaxAge, ServiceDetails, Target, UpnpNss, UpnpPort,
-    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext_},
+    header::{BootId, ConfigId, Location, SecureLocation, Server},
     uri::UriExt,
 };
 
@@ -59,7 +59,7 @@ pub struct Alive {
     /// checking for changes to the device state that were not evented since the device was off-line.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    boot_id: BootId,
+    boot_id: Option<BootId>,
     /// `CONFIGID.UPNP.ORG`: number used for caching description information.
     /// If a device sends out two messages with a `CONFIGID.UPNP.ORG` header field with the same field
     /// value, the configuration shall be the same at the moments that these messages were sent.
@@ -67,7 +67,7 @@ pub struct Alive {
     /// control point receives an announcement of an unknown configuration is downloading required.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    config_id: ConfigId,
+    config_id: Option<ConfigId>,
     /// `SEARCHPORT.UPNP.ORG`: number identifies port on which device responds to unicast M-SEARCH
     ///
     /// Optional (handled semantically in [UpnpPort])
@@ -87,8 +87,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Alive {
         let server = Server::get_from(&header)?;
         let uuid = *Usn::from_uri_and_nt(&header.try_get(Usn::HEADER_KEY)?.parse::<Uri>()?, &nt)?
             .as_uuid();
-        let boot_id = BootId::get_validated(&header, server.upnp_version)?;
-        let config_id = ConfigId::get_validated(&header, server.upnp_version)?;
+        let boot_id = Option::<BootId>::get_from(&header)?;
+        let config_id = Option::<ConfigId>::get_from(&header)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
         let secure_location = Option::<SecureLocation>::get_from(&header)?;
         Ok(Self {
@@ -119,7 +119,7 @@ pub struct ByeBye {
     /// checking for changes to the device state that were not evented since the device was off-line.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    boot_id: BootId,
+    boot_id: Option<BootId>,
     /// `CONFIGID.UPNP.ORG`: number used for caching description information.
     /// If a device sends out two messages with a `CONFIGID.UPNP.ORG` header field with the same field
     /// value, the configuration shall be the same at the moments that these messages were sent.
@@ -127,7 +127,7 @@ pub struct ByeBye {
     /// control point receives an announcement of an unknown configuration is downloading required.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    config_id: ConfigId,
+    config_id: Option<ConfigId>,
 }
 
 impl<'h> TryFrom<UpnpHeader<'h>> for ByeBye {
@@ -139,8 +139,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for ByeBye {
             .as_uuid();
         // TODO - document Boot & ConfigID validation must be done by something that has a
         // suitable cache from previous Alive & Update notifications
-        let boot_id: BootId = header.get(BootId::HEADER_KEY).try_into()?;
-        let config_id: ConfigId = header.get(ConfigId::HEADER_KEY).try_into()?;
+        let boot_id = Option::<BootId>::get_from(&header)?;
+        let config_id = Option::<ConfigId>::get_from(&header)?;
         Ok(Self {
             nt,
             uuid,

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 
 use crate::message::{
     HeaderExt,
-    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2},
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext},
 };
 
 use super::{ErrorKind, Header, MaxAge, ParseError, RFC1123, ST, UpnpHeader, UpnpPort};
@@ -72,10 +72,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Response {
         let server = Server::get_from(&header)?;
         let st = ST::get_from(&header)?;
         let usn = header.try_get("USN")?.to_string();
-        let boot_id: BootId = header.get(BootId::HEADER_KEY).try_into()?;
-        boot_id.validate(server.upnp_version)?;
-        let config_id: ConfigId = header.get(ConfigId::HEADER_KEY).try_into()?;
-        config_id.validate(server.upnp_version)?;
+        let boot_id = BootId::get_validated(&header, server.upnp_version)?;
+        let config_id = ConfigId::get_validated(&header, server.upnp_version)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
         let secure_location: SecureLocation = header.get(SecureLocation::HEADER_KEY).try_into()?;
         secure_location.validate()?;

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -17,19 +17,19 @@ pub struct Response {
     /// `CACHE-CONTROL`: Duration (in seconds) until advertisement expires
     pub max_age: MaxAge,
     /// `DATE`: when response was generated
-    date: Option<DateTime<Utc>>,
+    pub date: Option<DateTime<Utc>>,
     /// `EXT`: Required for backwards compatibility with UPnP 1.0. (Header field name only; no field value.)
     ext: Option<!>,
     /// `URL` for UPnP description for root device
-    location: Location,
+    pub location: Location,
     /// `SERVER`: OS/version UPnP/2.0 product/version
-    server: Server,
+    pub server: Server,
     /// `ST`: search target
-    st: ST,
+    pub st: ST,
     /// `USN`: composite identifier for the advertisement
     ///
     /// **TODO** handle USN nicely
-    usn: String,
+    pub usn: String,
     /// `BOOTID.UPNP.ORG`: the boot instance of the device expressed according to a monotonically
     /// increasing value. Control points can use this header field to detect the case when a device
     /// leaves and rejoins the network (“reboots” in UPnP terms). It can be used by
@@ -37,7 +37,7 @@ pub struct Response {
     /// checking for changes to the device state that were not evented since the device was off-line.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    boot_id: BootId,
+    pub boot_id: BootId,
     /// `CONFIGID.UPNP.ORG`: number used for caching description information.
     /// If a device sends out two messages with a `CONFIGID.UPNP.ORG` header field with the same field
     /// value, the configuration shall be the same at the moments that these messages were sent.
@@ -45,14 +45,14 @@ pub struct Response {
     /// control point receives an announcement of an unknown configuration is downloading required.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    config_id: ConfigId,
+    pub config_id: ConfigId,
     /// `SEARCHPORT.UPNP.ORG`: number identifies port on which device responds to unicast M-SEARCH
     ///
     /// Optional (handled semantically in [UpnpPort])
-    port: UpnpPort,
+    pub port: UpnpPort,
     /// `SECURELOCATION.UPNP.ORG`: provides a base URL, with `https:` scheme and a specific port.
     /// Required when device protection is implemented.
-    secure_location: Option<SecureLocation>,
+    pub secure_location: Option<SecureLocation>,
 }
 impl<'h> TryFrom<UpnpHeader<'h>> for Response {
     type Error = ParseError;

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 
 use crate::message::{
     HeaderExt,
-    header::{BootId, ConfigId, Location, SecureLocation, Server},
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext},
 };
 
 use super::{ErrorKind, Header, MaxAge, ParseError, RFC1123, ST, UpnpHeader, UpnpPort};
@@ -72,8 +72,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Response {
         let server = Server::get_from(&header)?;
         let st = ST::get_from(&header)?;
         let usn = header.try_get("USN")?.to_string();
-        let boot_id = Option::<BootId>::get_from(&header)?;
-        let config_id = Option::<ConfigId>::get_from(&header)?;
+        let boot_id = Option::<BootId>::get_validated(&header, server.upnp_version)?;
+        let config_id = Option::<ConfigId>::get_validated(&header, server.upnp_version)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
         let secure_location = Option::<SecureLocation>::get_from(&header)?;
         Ok(Self {

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -1,6 +1,9 @@
 use chrono::{DateTime, NaiveDateTime, Utc};
 
-use crate::message::header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2};
+use crate::message::{
+    HeaderExt,
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2},
+};
 
 use super::{ErrorKind, Header, MaxAge, ParseError, RFC1123, ST, UpnpHeader, UpnpPort};
 
@@ -55,7 +58,7 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Response {
     type Error = ParseError;
 
     fn try_from(header: UpnpHeader<'h>) -> Result<Self, Self::Error> {
-        let max_age = header.try_get(MaxAge::HEADER_KEY)?.parse()?;
+        let max_age = MaxAge::get_from(&header)?;
         let date = header
             .get("DATE")
             .map(|date| {

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -68,9 +68,9 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Response {
             })
             .transpose()?;
         let ext = None;
-        let location = header.try_get(Location::HEADER_KEY)?.parse()?;
-        let server: Server = header.try_get(Server::HEADER_KEY)?.parse()?;
-        let st = header.try_get(ST::HEADER_KEY)?.parse()?;
+        let location = Location::get_from(&header)?;
+        let server = Server::get_from(&header)?;
+        let st = ST::get_from(&header)?;
         let usn = header.try_get("USN")?.to_string();
         let boot_id: BootId = header.get(BootId::HEADER_KEY).try_into()?;
         boot_id.validate(server.upnp_version)?;

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 
 use crate::message::{
     HeaderExt,
-    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext_},
+    header::{BootId, ConfigId, Location, SecureLocation, Server},
 };
 
 use super::{ErrorKind, Header, MaxAge, ParseError, RFC1123, ST, UpnpHeader, UpnpPort};
@@ -37,7 +37,7 @@ pub struct Response {
     /// checking for changes to the device state that were not evented since the device was off-line.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    pub boot_id: BootId,
+    pub boot_id: Option<BootId>,
     /// `CONFIGID.UPNP.ORG`: number used for caching description information.
     /// If a device sends out two messages with a `CONFIGID.UPNP.ORG` header field with the same field
     /// value, the configuration shall be the same at the moments that these messages were sent.
@@ -45,7 +45,7 @@ pub struct Response {
     /// control point receives an announcement of an unknown configuration is downloading required.
     ///
     /// Required for UPnPv2, not present in UPnPv1
-    pub config_id: ConfigId,
+    pub config_id: Option<ConfigId>,
     /// `SEARCHPORT.UPNP.ORG`: number identifies port on which device responds to unicast M-SEARCH
     ///
     /// Optional (handled semantically in [UpnpPort])
@@ -72,8 +72,8 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Response {
         let server = Server::get_from(&header)?;
         let st = ST::get_from(&header)?;
         let usn = header.try_get("USN")?.to_string();
-        let boot_id = BootId::get_validated(&header, server.upnp_version)?;
-        let config_id = ConfigId::get_validated(&header, server.upnp_version)?;
+        let boot_id = Option::<BootId>::get_from(&header)?;
+        let config_id = Option::<ConfigId>::get_from(&header)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
         let secure_location = Option::<SecureLocation>::get_from(&header)?;
         Ok(Self {

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -52,7 +52,7 @@ pub struct Response {
     port: UpnpPort,
     /// `SECURELOCATION.UPNP.ORG`: provides a base URL, with `https:` scheme and a specific port.
     /// Required when device protection is implemented.
-    secure_location: SecureLocation,
+    secure_location: Option<SecureLocation>,
 }
 impl<'h> TryFrom<UpnpHeader<'h>> for Response {
     type Error = ParseError;
@@ -75,8 +75,7 @@ impl<'h> TryFrom<UpnpHeader<'h>> for Response {
         let boot_id = BootId::get_validated(&header, server.upnp_version)?;
         let config_id = ConfigId::get_validated(&header, server.upnp_version)?;
         let port = header.get(UpnpPort::HEADER_KEY).try_into()?;
-        let secure_location: SecureLocation = header.get(SecureLocation::HEADER_KEY).try_into()?;
-        secure_location.validate()?;
+        let secure_location = Option::<SecureLocation>::get_from(&header)?;
         Ok(Self {
             max_age,
             date,

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, NaiveDateTime, Utc};
 
 use crate::message::{
     HeaderExt,
-    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext},
+    header::{BootId, ConfigId, Location, SecureLocation, Server, UpnpV2Ext_},
 };
 
 use super::{ErrorKind, Header, MaxAge, ParseError, RFC1123, ST, UpnpHeader, UpnpPort};

--- a/ssdp-rs/src/message/response.rs
+++ b/ssdp-rs/src/message/response.rs
@@ -15,7 +15,7 @@ use super::{ErrorKind, Header, MaxAge, ParseError, RFC1123, ST, UpnpHeader, Upnp
 /// these messages.
 pub struct Response {
     /// `CACHE-CONTROL`: Duration (in seconds) until advertisement expires
-    max_age: MaxAge,
+    pub max_age: MaxAge,
     /// `DATE`: when response was generated
     date: Option<DateTime<Utc>>,
     /// `EXT`: Required for backwards compatibility with UPnP 1.0. (Header field name only; no field value.)

--- a/ssdp-rs/src/search.rs
+++ b/ssdp-rs/src/search.rs
@@ -3,11 +3,11 @@
 //! ## Example usage
 //! ```no_run
 //! # // no reply possible so not run as test to avoid endless loop
-//! # use std::{io, net::Ipv4Addr};
+//! # use std::net::Ipv4Addr;
 //! use futures::StreamExt;
-//! use ssdp_rs::{Listener, Searcher};
+//! use ssdp_rs::{Listener, Result, Searcher};
 //!
-//! # fn main() -> io::Result<()> {
+//! # fn main() -> Result<()> {
 //! // Create a new searcher
 //! let mut searcher = Searcher::new(
 //!     "splurt",
@@ -44,7 +44,7 @@ use futures_udp::{EventedUdpSocket, UdpSink};
 use uuid::Uuid;
 
 use crate::{
-    MULTICAST, SSDP_PORT,
+    MULTICAST, Result, SSDP_PORT,
     message::{Message, Mx},
 };
 
@@ -69,7 +69,7 @@ pub struct Searcher {
 
 /// Create a new Searcher with default values as per [UpnpMessenger::build_searcher]
 impl Searcher {
-    pub fn new(product_name: &str, product_version: &str, friendly_name: &str) -> io::Result<Self> {
+    pub fn new(product_name: &str, product_version: &str, friendly_name: &str) -> Result<Self> {
         UpnpMessenger::new(product_name, product_version, friendly_name).build_searcher()
     }
 
@@ -219,7 +219,7 @@ impl<'bldr> UpnpMessenger<'bldr> {
     /// - Repeat: 5
     /// - Repeat delay: 5s
     /// - Resend every: 15 mins
-    pub fn build_searcher(&mut self) -> io::Result<Searcher> {
+    pub fn build_searcher(&mut self) -> Result<Searcher> {
         let ip = self.addr.unwrap_or(Ipv4Addr::UNSPECIFIED);
         let port = self.port.unwrap_or(SSDP_PORT);
         let addr = SocketAddrV4::new(ip, port).into();


### PR DESCRIPTION
- with helper traits:
  - HeaderExt::get_from
  - UpnpV2Ext::get_validated
- revert semantics of optional BootId etc to be Option<BootId>
- leverage derive_more to reduce Boilerplate for From, Into, FromStr on NewTypes